### PR TITLE
Move expensive operations off the main thread, fix cache double-populate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: `.getServices()` typed request.
 - Added: `.getStates()` typed request.
 - Changed: `attributes` and `context` on `HAEntity` are now represented by parsed types.
+- Changed: Many internal cases of JSON parsing and decoding are now done off the main thread.
 - Fixed: Calling `connect()` when already connected no longer disconnects and reconnects.
 
 ## [0.1.0] - 2021-03-05

--- a/Source/Caches/HACache.swift
+++ b/Source/Caches/HACache.swift
@@ -143,8 +143,9 @@ public class HACache<ValueType> {
         let info = SubscriptionInfo(handler: handler)
         let cancellable = self.cancellable(for: info)
 
-        let wasEmpty: Bool = state.mutate { state in
+        let shouldRefresh: Bool = state.mutate { state in
             let wasEmpty = state.subscribers.isEmpty
+            let shouldRefresh = state.current == nil || state.shouldResetWithoutSubscribers
             state.subscribers.insert(info)
 
             // we know that if any state changes happen _after_ this, it'll be notified in another block
@@ -154,11 +155,11 @@ public class HACache<ValueType> {
                 }
             }
 
-            return wasEmpty
+            return wasEmpty && shouldRefresh
         }
 
         // if we are waiting on subscribers to start, we can do so now
-        if wasEmpty {
+        if shouldRefresh {
             checkStateAndStart()
         }
 

--- a/Source/Caches/HACache.swift
+++ b/Source/Caches/HACache.swift
@@ -271,7 +271,7 @@ public class HACache<ValueType> {
     }
 
     /// The connection to use and watch
-    internal private(set) weak var connection: HAConnection?
+    internal weak var connection: HAConnection?
     /// Block to begin the prepare -> subscribe lifecycle
     /// This is a block to erase all the intermediate types for prepare/subscribe
     private let start: ((HAConnection, HACache<ValueType>) -> HACancellable?)?

--- a/Source/Internal/HAConnectionImpl.swift
+++ b/Source/Internal/HAConnectionImpl.swift
@@ -8,7 +8,7 @@ internal class HAConnectionImpl: HAConnection {
     public var configuration: HAConnectionConfiguration
 
     public var callbackQueue: DispatchQueue = .main
-    internal var workQueue: DispatchQueue = DispatchQueue(
+    internal var workQueue = DispatchQueue(
         label: "hakit-work-queue",
         autoreleaseFrequency: .workItem,
         target: .global()

--- a/Source/Internal/RequestController/HARequestController.swift
+++ b/Source/Internal/RequestController/HARequestController.swift
@@ -13,6 +13,7 @@ internal protocol HARequestControllerDelegate: AnyObject {
 
 internal protocol HARequestController: AnyObject {
     var delegate: HARequestControllerDelegate? { get set }
+    var workQueue: DispatchQueue { get set }
 
     func add(_ invocation: HARequestInvocation)
     func cancel(_ request: HARequestInvocation)
@@ -47,6 +48,7 @@ internal class HARequestControllerImpl: HARequestController {
     }
 
     weak var delegate: HARequestControllerDelegate?
+    var workQueue: DispatchQueue = .global()
 
     private var state = HAProtected<State>(value: .init())
 

--- a/Source/Internal/ResponseController/HAResponseController.swift
+++ b/Source/Internal/ResponseController/HAResponseController.swift
@@ -32,6 +32,7 @@ internal enum HAResponseControllerPhase: Equatable {
 
 internal protocol HAResponseController: AnyObject {
     var delegate: HAResponseControllerDelegate? { get set }
+    var workQueue: DispatchQueue { get set }
     var phase: HAResponseControllerPhase { get }
 
     func reset()
@@ -40,6 +41,7 @@ internal protocol HAResponseController: AnyObject {
 
 internal class HAResponseControllerImpl: HAResponseController {
     weak var delegate: HAResponseControllerDelegate?
+    var workQueue: DispatchQueue = .global()
 
     private(set) var phase: HAResponseControllerPhase = .disconnected(error: nil, forReset: true) {
         didSet {
@@ -63,33 +65,45 @@ internal class HAResponseControllerImpl: HAResponseController {
             HAGlobal.log("disconnected: \(reason) with code: \(code)")
             phase = .disconnected(error: nil, forReset: false)
         case let .text(string):
-            do {
-                if let data = string.data(using: .utf8),
-                   let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                    let response = try HAWebSocketResponse(dictionary: json)
+            workQueue.async { [self] in
+                let response: HAWebSocketResponse
 
-                    switch response {
-                    case let .auth(state):
-                        HAGlobal.log("Received: auth: \(state)")
-                    case let .event(identifier: identifier, data: _):
-                        HAGlobal.log("Received: event: for \(identifier)")
-                    case let .result(identifier: identifier, result: result):
-                        switch result {
-                        case .success:
-                            HAGlobal.log("Received: result success \(identifier)")
-                        case let .failure(error):
-                            HAGlobal.log("Received: result failure \(identifier): \(error) via \(string)")
-                        }
+                do {
+                    guard let data = string.data(using: .utf8) else {
+                        throw HAError.internal(debugDescription: "missing data conversion")
                     }
 
+                    guard let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+                        throw HAError.internal(debugDescription: "couldn't convert to dictionary")
+                    }
+
+                    response = try HAWebSocketResponse(dictionary: json)
+                } catch {
+                    HAGlobal.log("text parse error: \(error)")
+                    return
+                }
+
+                switch response {
+                case let .auth(state):
+                    HAGlobal.log("Received: auth: \(state)")
+                case let .event(identifier: identifier, data: _):
+                    HAGlobal.log("Received: event: for \(identifier)")
+                case let .result(identifier: identifier, result: result):
+                    switch result {
+                    case .success:
+                        HAGlobal.log("Received: result success \(identifier)")
+                    case let .failure(error):
+                        HAGlobal.log("Received: result failure \(identifier): \(error) via \(string)")
+                    }
+                }
+
+                DispatchQueue.main.async {
                     if case let .auth(.ok(version)) = response {
                         phase = .command(version: version)
                     }
 
                     delegate?.responseController(self, didReceive: response)
                 }
-            } catch {
-                HAGlobal.log("text parse error: \(error)")
             }
         case let .binary(data):
             HAGlobal.log("Received binary data: \(data.count)")

--- a/Source/Internal/ResponseController/HAResponseController.swift
+++ b/Source/Internal/ResponseController/HAResponseController.swift
@@ -69,9 +69,8 @@ internal class HAResponseControllerImpl: HAResponseController {
                 let response: HAWebSocketResponse
 
                 do {
-                    guard let data = string.data(using: .utf8) else {
-                        throw HAError.internal(debugDescription: "missing data conversion")
-                    }
+                    // https://forums.swift.org/t/can-encoding-string-to-data-with-utf8-fail/22437/4
+                    let data = string.data(using: .utf8)!
 
                     guard let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
                         throw HAError.internal(debugDescription: "couldn't convert to dictionary")

--- a/Tests/HACache.test.swift
+++ b/Tests/HACache.test.swift
@@ -564,6 +564,23 @@ internal class HACacheTests: XCTestCase {
         XCTAssertEqual(populateCount, 3)
         XCTAssertNotNil(populatePerform)
     }
+
+    func testSubscribePopulateUnsubscribeSubscribeDoesntReissuePopulate() throws {
+        connection.state = .ready(version: "1.2.3")
+
+        let token1 = cache.subscribe { _, _ in }
+
+        try populate { current in
+            XCTAssertNil(current)
+            return CacheItem()
+        }
+
+        token1.cancel()
+
+        _ = cache.subscribe { _, _ in }
+
+        XCTAssertEqual(populateCount, 1)
+    }
 }
 
 private struct CacheItem: Equatable {

--- a/Tests/HACache.test.swift
+++ b/Tests/HACache.test.swift
@@ -136,6 +136,15 @@ internal class HACacheTests: XCTestCase {
         XCTAssertEqual(cache.map(\.uuid).value, expected.uuid)
     }
 
+    func testSubscribingAfterConnectionGoesAway() throws {
+        cache.connection = nil
+        _ = cache.subscribe { _, _ in
+        }
+
+        // honestly, it just shouldn't _crash_
+        XCTAssertEqual(populateCount, 0)
+    }
+
     func testSubscribingSkipsConnectionInitially() throws {
         connection.state = .disconnected(reason: .disconnected)
         _ = cache.subscribe { _, _ in

--- a/Tests/HACache.test.swift
+++ b/Tests/HACache.test.swift
@@ -8,6 +8,7 @@ import XCTest
 
 internal class HACacheTests: XCTestCase {
     private var cache: HACache<CacheItem>!
+    private var workQueue: DispatchQueue!
 
     private var queueSpecific = DispatchSpecificKey<Bool>()
     private var connection: HAMockConnection!
@@ -24,17 +25,34 @@ internal class HACacheTests: XCTestCase {
     private var subscribeCancellableInvoked2: Bool = false
     private var subscribePerform2: (((CacheItem) -> HACacheSubscribeInfo<CacheItem>.Response) -> Void)?
 
+    private func waitForCallback() {
+        let expectation = self.expectation(description: "waiting for queue")
+        workQueue.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 10.0)
+    }
+
     private func populate(_ block: (CacheItem?) -> CacheItem) throws {
+        if populatePerform == nil {
+            waitForCallback()
+        }
         let value = try XCTUnwrap(populatePerform)
         value(block)
     }
 
     private func subscribe(_ block: (CacheItem) -> HACacheSubscribeInfo<CacheItem>.Response) throws {
+        if subscribePerform == nil {
+            waitForCallback()
+        }
         let value = try XCTUnwrap(subscribePerform)
         value(block)
     }
 
     private func subscribe2(_ block: (CacheItem) -> HACacheSubscribeInfo<CacheItem>.Response) throws {
+        if subscribePerform2 == nil {
+            waitForCallback()
+        }
         let value = try XCTUnwrap(subscribePerform2)
         value(block)
     }
@@ -89,6 +107,7 @@ internal class HACacheTests: XCTestCase {
         queueSpecific = .init()
         connection.callbackQueue = DispatchQueue(label: "test-callback-queue")
         connection.callbackQueue.setSpecific(key: queueSpecific, value: true)
+        workQueue = DispatchQueue(label: "work-queue", autoreleaseFrequency: .workItem, target: .global())
 
         cache = HACache<CacheItem>(connection: connection, populate: populateInfo, subscribe: subscribeInfo)
     }
@@ -181,53 +200,6 @@ internal class HACacheTests: XCTestCase {
         cache.shouldResetWithoutSubscribers = true
         XCTAssertTrue(cache.shouldResetWithoutSubscribers)
         XCTAssertTrue(populateCancellableInvoked)
-    }
-
-    func testPopulateSendsOnRetryToo() throws {
-        connection.state = .ready(version: "1.2.3")
-
-        let expectedItem1 = CacheItem()
-
-        let expectation1 = expectation(description: "notified1")
-        let handlerToken1 = cache.subscribe { _, value in
-            XCTAssertTrue(self.isOnCallbackQueue)
-            XCTAssertEqual(value, expectedItem1)
-            expectation1.fulfill()
-        }
-
-        try populate { current in
-            XCTAssertNil(current)
-            return expectedItem1
-        }
-
-        waitForExpectations(timeout: 10)
-
-        handlerToken1.cancel()
-        populatePerform = nil
-
-        let expectedItem2 = CacheItem()
-
-        let expectation2 = expectation(description: "notified2")
-
-        // one initial (since we have a value) and then the after
-        expectation2.expectedFulfillmentCount = 2
-
-        var handler2Values = [CacheItem]()
-        _ = cache.subscribe { _, value in
-            XCTAssertTrue(self.isOnCallbackQueue)
-            handler2Values.append(value)
-            expectation2.fulfill()
-        }
-
-        try populate { current in
-            XCTAssertEqual(current, expectedItem1)
-            return expectedItem2
-        }
-
-        waitForExpectations(timeout: 10)
-
-        XCTAssertEqual(populateCount, 2)
-        XCTAssertEqual(handler2Values, [expectedItem1, expectedItem2])
     }
 
     func testPopulateThenSubscribes() throws {
@@ -464,7 +436,6 @@ internal class HACacheTests: XCTestCase {
         XCTAssertEqual(mappedCache.value, expectedValue.uuid)
 
         let handlerExpectation = expectation(description: "handler")
-        handlerExpectation.expectedFulfillmentCount = 2
         _ = mappedCache.subscribe { _, value in
             XCTAssertTrue(self.isOnCallbackQueue)
             XCTAssertEqual(value, expectedValue.uuid)

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -63,6 +63,12 @@ internal class HAConnectionImplTests: XCTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) throws {
+        let expectation = self.expectation(description: "queue-jumping")
+        connection.workQueue.async {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 10.0)
+
         let lastEvent = try XCTUnwrap(engine.events.last)
 
         switch lastEvent {
@@ -1177,6 +1183,7 @@ private class FakeHAConnectionDelegate: HAConnectionDelegate {
 
 private class FakeHARequestController: HARequestController {
     weak var delegate: HARequestControllerDelegate?
+    var workQueue: DispatchQueue = .main
 
     var added: [HARequestInvocation] = []
     func add(_ invocation: HARequestInvocation) {
@@ -1227,6 +1234,7 @@ private class FakeHARequestController: HARequestController {
 
 private class FakeHAResponseController: HAResponseController {
     weak var delegate: HAResponseControllerDelegate?
+    var workQueue: DispatchQueue = .main
 
     var phase: HAResponseControllerPhase = .disconnected(error: nil, forReset: true)
 

--- a/Tests/HARequestController.test.swift
+++ b/Tests/HARequestController.test.swift
@@ -12,6 +12,7 @@ internal class HARequestControllerTests: XCTestCase {
         delegate = TestHARequestControllerDelegate()
         controller = HARequestControllerImpl()
         controller.delegate = delegate
+        controller.workQueue = DispatchQueue(label: "unit-test-work-queue")
     }
 
     func testAddingWhenNotAllowed() {

--- a/Tests/HAResponseController.test.swift
+++ b/Tests/HAResponseController.test.swift
@@ -107,9 +107,9 @@ internal class HAResponseControllerTests: XCTestCase {
 
     func testInvalidText() throws {
         fireConnected()
-        let text = "{json lol"
 
-        controller.didReceive(event: .text(text))
+        controller.didReceive(event: .text("{"))
+        controller.didReceive(event: .text("[true]"))
 
         waitForCallback()
 

--- a/Tests/HAResponseController.test.swift
+++ b/Tests/HAResponseController.test.swift
@@ -107,11 +107,12 @@ internal class HAResponseControllerTests: XCTestCase {
 
     func testInvalidText() throws {
         fireConnected()
-        try fireText(
-            from: [:],
-            expectingResponse: false,
-            expectingPhase: .auth
-        )
+        let text = "{json lol"
+
+        controller.didReceive(event: .text(text))
+
+        waitForCallback()
+
         XCTAssertNil(delegate.lastReceived)
     }
 }


### PR DESCRIPTION
- Particularly the JSON parsing, but running `HAEntity` decoding for many states is extremely expensive due to the date parsing.
- Fixes sending a new populate when (1) subscribe, (2) populate success, (3) unsubscribe, (4) subscribe. 