### PR TITLE
Fix re-entrant lock attempt crash and make populate requests retry

### DIFF
--- a/Extensions/Mocks/HAConnection+Mock.swift
+++ b/Extensions/Mocks/HAConnection+Mock.swift
@@ -212,17 +212,17 @@ public class HAMockConnection: HAConnection {
         let runLoopSource = CFRunLoopSourceCreate(nil, 0, &context)
         CFRunLoopAddSource(runLoop, runLoopSource, runLoopMode)
 
-        var hasCalled = false
+        var hasCalled: Int32 = 0
 
         let stop = {
-            hasCalled = true
+            OSAtomicCompareAndSwap32(0, 1, &hasCalled)
             CFRunLoopStop(runLoop)
         }
 
         callbackQueue.async(execute: stop)
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(5), execute: stop)
 
-        while !hasCalled {
+        while hasCalled == 0 {
             CFRunLoopRunInMode(runLoopMode, 1.0, false)
         }
     }

--- a/Extensions/Mocks/HAConnection+Mock.swift
+++ b/Extensions/Mocks/HAConnection+Mock.swift
@@ -96,6 +96,7 @@ public class HAMockConnection: HAConnection {
             }
         }
     }
+
     public func setState(_ state: HAConnectionState, waitForQueue: Bool = true) {
         self.state = state
         if waitForQueue {
@@ -204,7 +205,7 @@ public class HAMockConnection: HAConnection {
 
     public func waitForCallbackQueue() {
         precondition(Thread.isMainThread)
-        let runLoopMode: CFRunLoopMode = CFRunLoopMode.defaultMode
+        let runLoopMode = CFRunLoopMode.defaultMode
 
         var context = CFRunLoopSourceContext()
         let runLoop = CFRunLoopGetCurrent()

--- a/Source/Caches/HACache.swift
+++ b/Source/Caches/HACache.swift
@@ -46,7 +46,7 @@ public class HACache<ValueType> {
         self.subscribeInfo = subscribe
 
         self.start = { connection, cache in
-            return Self.startPopulate(for: populate, on: connection, cache: cache) { cache in
+            Self.startPopulate(for: populate, on: connection, cache: cache) { cache in
                 cache.state.mutate { state in
                     let tokens = subscribe.map { info in
                         Self.startSubscribe(to: info, on: connection, populate: populate, cache: cache)

--- a/Source/Internal/HAConnectionImpl.swift
+++ b/Source/Internal/HAConnectionImpl.swift
@@ -30,11 +30,13 @@ internal class HAConnectionImpl: HAConnection {
     }
 
     internal func notifyState() {
-        delegate?.connection(self, didTransitionTo: state)
-        NotificationCenter.default.post(
-            name: HAConnectionState.didTransitionToStateNotification,
-            object: self
-        )
+        callbackQueue.async { [self, state] in
+            delegate?.connection(self, didTransitionTo: state)
+            NotificationCenter.default.post(
+                name: HAConnectionState.didTransitionToStateNotification,
+                object: self
+            )
+        }
     }
 
     internal private(set) var connection: WebSocket? {

--- a/Tests/HACache.test.swift
+++ b/Tests/HACache.test.swift
@@ -172,7 +172,10 @@ internal class HACacheTests: XCTestCase {
                     fatalError()
                 }, start: { [populateInfo] connection, perform in
                     _ = populateInfo?.start(connection, perform)
-                    return connection.send(HATypedRequest<HAResponseVoid>(request: .init(type: "none", data: [:])), completion: { _ in })
+                    return connection.send(
+                        HATypedRequest<HAResponseVoid>(request: .init(type: "none", data: [:])),
+                        completion: { _ in }
+                    )
                 }
             ),
             subscribe: subscribeInfo
@@ -234,7 +237,7 @@ internal class HACacheTests: XCTestCase {
             expectation.fulfill()
         }
 
-        try populate { current in
+        try populate { _ in
             throw HAError.internal(debugDescription: "unit test")
         }
 

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -35,7 +35,6 @@ internal class HAConnectionImplTests: XCTestCase {
         requestController = FakeHARequestController()
         responseController = FakeHAResponseController()
         reconnectManager = FakeHAReconnectManager()
-        delegate = FakeHAConnectionDelegate()
 
         queueSpecific = .init()
         callbackQueue = DispatchQueue(label: "test-callback-queue")
@@ -60,6 +59,8 @@ internal class HAConnectionImplTests: XCTestCase {
             reconnectManager: reconnectManager
         )
         connection.callbackQueue = callbackQueue
+
+        delegate = FakeHAConnectionDelegate(connection: connection)
         connection.delegate = delegate
     }
 
@@ -1178,10 +1179,10 @@ private class MockTypedRequestResult: HADataDecodable {
 private class FakeHAConnectionDelegate: HAConnectionDelegate {
     private var token: Any?
 
-    init() {
+    init(connection: HAConnectionImpl) {
         self.token = NotificationCenter.default.addObserver(
             forName: HAConnectionState.didTransitionToStateNotification,
-            object: nil,
+            object: connection,
             queue: nil,
             using: { [weak self] _ in
                 self?.notifiedCount += 1

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -1177,7 +1177,7 @@ private class MockTypedRequestResult: HADataDecodable {
 
 private class FakeHAConnectionDelegate: HAConnectionDelegate {
     private var token: Any?
- 
+
     init() {
         self.token = NotificationCenter.default.addObserver(
             forName: HAConnectionState.didTransitionToStateNotification,


### PR DESCRIPTION
This reduces some complexity around state management -- we don't need to care about whether we need to send a populate again due to state changes, because we can assume if one is outstanding that it'll be handled by the connection.

This mitigates a bug where our using the state change as a signal to start populate recursed due to populate, itself, causing a change to `.connecting`. State changes are now just a signal that a populate should happen at all. A second level of this was making the state change events happen in the callback queue, rather than whenever the state changed.

Fixes #17.