### PR TITLE
Retry failed subscriptions when config/components change

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/HAKit.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/HAKit.xcscheme
@@ -88,6 +88,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added: Subscriptions will now retry (when their request `shouldRetry`) when the HA config changes or components are loaded.
 - Changed: `HAConnectionInfo` now has a throwing initializer. See `HAConnectionInfo.CreationError` for details.
 
 ## [0.2.2] - 2021-05-01

--- a/Source/Internal/RequestController/HARequestInvocationSubscription.swift
+++ b/Source/Internal/RequestController/HARequestInvocationSubscription.swift
@@ -1,6 +1,7 @@
 internal class HARequestInvocationSubscription: HARequestInvocation {
     private var handler: HAResetLock<HAConnection.SubscriptionHandler>
     private var initiated: HAResetLock<HAConnection.SubscriptionInitiatedHandler>
+    private var lastInitiatedResult: Result<HAData, HAError>?
 
     init(
         request: HARequest,
@@ -18,6 +19,14 @@ internal class HARequestInvocationSubscription: HARequestInvocation {
         initiated.reset()
     }
 
+    internal var needsRetry: Bool {
+        if case .failure = lastInitiatedResult {
+            return true
+        } else {
+            return false
+        }
+    }
+
     override var needsAssignment: Bool {
         // not initiated, since it is optional
         super.needsAssignment && handler.read() != nil
@@ -32,6 +41,7 @@ internal class HARequestInvocationSubscription: HARequestInvocation {
     }
 
     func resolve(_ result: Result<HAData, HAError>) {
+        lastInitiatedResult = result
         initiated.read()?(result)
     }
 

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -165,13 +165,14 @@ internal class HAConnectionImplTests: XCTestCase {
     func testSubscribeRetryEvents() {
         requestController.retrySubscriptionsEvents = ["event1", "event2"]
         connection.connect()
+        connection.connect()
 
         responseController.phase = .command(version: "123")
         connection.responseController(responseController, didTransitionTo: .command(version: "123"))
         waitForCallbackQueue()
 
         let subscriptions = requestController.added.compactMap { $0 as? HARequestInvocationSubscription }
-        XCTAssertFalse(subscriptions.isEmpty)
+        XCTAssertEqual(subscriptions.count, requestController.retrySubscriptionsEvents.count)
 
         for subscription in subscriptions {
             requestController.didResetSubscriptions = false

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -29,6 +29,12 @@ internal class HAConnectionImplTests: XCTestCase {
         waitForExpectations(timeout: 10.0)
     }
 
+    private func waitForWorkQueue() {
+        let expectation = self.expectation(description: "work queue wait once")
+        connection.workQueue.async(execute: expectation.fulfill)
+        waitForExpectations(timeout: 10.0)
+    }
+
     override func setUp() {
         super.setUp()
 
@@ -70,11 +76,7 @@ internal class HAConnectionImplTests: XCTestCase {
         file: StaticString = #file,
         line: UInt = #line
     ) throws {
-        let expectation = self.expectation(description: "queue-jumping")
-        connection.workQueue.async {
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 10.0)
+        waitForWorkQueue()
 
         let lastEvent = try XCTUnwrap(engine.events.last)
 
@@ -186,11 +188,8 @@ internal class HAConnectionImplTests: XCTestCase {
                 }
             }
             """))
-            let expectation = self.expectation(description: "queue-jumping")
-            connection.workQueue.async {
-                expectation.fulfill()
-            }
-            waitForExpectations(timeout: 10.0)
+            waitForWorkQueue()
+            waitForCallbackQueue()
             XCTAssertTrue(requestController.didResetSubscriptions)
         }
     }


### PR DESCRIPTION
This works around `mobile_app/push_notification_channel` being unavailable until the `mobile_app` component finishes loading, so instead of getting stuck it'll re-subscribe once it loads.

Fun way I tested this one:

```diff
diff --git a/homeassistant/components/mobile_app/__init__.py b/homeassistant/components/mobile_app/__init__.py
index 9633ec6556..23dfa8684d 100644
--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -1,6 +1,8 @@
 """Integrates Native Apps to Home Assistant."""
 from contextlib import suppress
 
+import asyncio
+
 import voluptuous as vol
 
 from homeassistant.components import cloud, notify as hass_notify, websocket_api
@@ -66,6 +68,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType):
         discovery.async_load_platform(hass, "notify", DOMAIN, {}, config)
     )
 
+    await asyncio.sleep(10)
+
     websocket_api.async_register_command(hass, handle_push_notification_channel)
 
     return True
```

This makes the mobile_app component take the full 10 seconds before it finishes and the websocket command is available.