### PR TITLE
Throw for ports >max in in HAConnectionInfo

### DIFF
--- a/Source/HAConnectionInfo.swift
+++ b/Source/HAConnectionInfo.swift
@@ -7,6 +7,8 @@ public struct HAConnectionInfo: Equatable {
     enum CreationError: Error {
         /// The URL's host was empty, which would otherwise crash if used
         case emptyHostname
+        /// The port provided exceeds the maximum allowed TCP port (2^16-1)
+        case invalidPort
     }
 
     /// Create a connection info
@@ -24,6 +26,10 @@ public struct HAConnectionInfo: Equatable {
     internal init(url: URL, userAgent: String?, engine: Engine?) throws {
         guard let host = url.host, !host.isEmpty else {
             throw CreationError.emptyHostname
+        }
+
+        guard (url.port ?? 80) <= UInt16.max else {
+            throw CreationError.invalidPort
         }
 
         self.url = Self.sanitize(url)

--- a/Tests/HAConnectionInfo.test.swift
+++ b/Tests/HAConnectionInfo.test.swift
@@ -100,6 +100,16 @@ internal class HAConnectionInfoTests: XCTestCase {
         XCTAssertThrowsError(try HAConnectionInfo(url: url1)) { error in
             XCTAssertEqual(error as? HAConnectionInfo.CreationError, .emptyHostname)
         }
+
+        for port in [
+            String(Int(UInt16.max) + 1),
+            "999999999999999",
+        ] {
+            let url2 = URL(string: "http://example.com:" + port)!
+            XCTAssertThrowsError(try HAConnectionInfo(url: url2)) { error in
+                XCTAssertEqual(error as? HAConnectionInfo.CreationError, .invalidPort)
+            }
+        }
     }
 
     func testShouldReplace() throws {

--- a/Tests/HAData.test.swift
+++ b/Tests/HAData.test.swift
@@ -306,9 +306,7 @@ internal class HADataTests: XCTestCase {
 
     func testDecodeWithThrowingTransform() throws {
         let value = HAData(value: ["name": "zacwest"])
-        XCTAssertThrowsError(try value.decode("name", transform: { (_: String) in
-            nil
-        }) as Int) { error in
+        XCTAssertThrowsError(try value.decode("name", transform: { (_: String) in nil }) as Int) { error in
             XCTAssertEqual(error as? HADataError, .couldntTransform(key: "name"))
         }
     }


### PR DESCRIPTION
Fixes a crash that looks like…

```
0   Starscream Swift runtime failure: Not enough bits to represent the passed value + 0 (TCPTransport.swift:0)
1   Starscream init + 4 (TCPTransport.swift:80)
2   Starscream TCPTransport.connect(url:timeout:certificatePinning:) + 1080
3   Starscream TCPTransport.connect(url:timeout:certificatePinning:) + 844 (TCPTransport.swift:80)
4   Starscream WSEngine.start(request:) + 656 (WSEngine.swift:67)
5   Starscream protocol witness for Engine.start(request:) in conformance WSEngine + 20 (<compiler-generated>:0)
6   Starscream WebSocket.connect() + 216 (WebSocket.swift:135)
7   HAKit      HAConnectionImpl.connection.didset + 264 (HAConnectionImpl.swift:49)
```