### PR TITLE
Delay resubscribing to subscriptions so we don't flood during startup

### DIFF
--- a/Source/Internal/HAReconnectManager.swift
+++ b/Source/Internal/HAReconnectManager.swift
@@ -61,32 +61,14 @@ internal class HAReconnectManagerImpl: HAReconnectManager {
     private(set) var retryCount: Int = 0
     private(set) var lastError: Error?
     private(set) var nextTimerDate: Date?
-    private(set) var reconnectTimer: Timer? {
-        willSet {
-            reconnectTimer?.invalidate()
-        }
-
+    @HASchedulingTimer private(set) var reconnectTimer: Timer? {
         didSet {
-            if let timer = reconnectTimer {
-                RunLoop.main.add(timer, forMode: .default)
-                nextTimerDate = timer.fireDate
-            } else {
-                nextTimerDate = nil
-            }
+            nextTimerDate = reconnectTimer?.fireDate
         }
     }
 
     private(set) var lastPingDuration: Measurement<UnitDuration>?
-    private(set) var pingTimer: Timer? {
-        willSet {
-            pingTimer?.invalidate()
-        }
-        didSet {
-            if let timer = pingTimer {
-                RunLoop.main.add(timer, forMode: .default)
-            }
-        }
-    }
+    @HASchedulingTimer private(set) var pingTimer: Timer?
 
     var reason: HAConnectionState.DisconnectReason {
         guard let nextTimerDate = nextTimerDate else {

--- a/Source/Internal/HASchedulingTimer.swift
+++ b/Source/Internal/HASchedulingTimer.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+@propertyWrapper
+internal struct HASchedulingTimer<WrappedValue: Timer> {
+    var wrappedValue: WrappedValue? {
+        willSet {
+            if wrappedValue != newValue {
+                wrappedValue?.invalidate()
+            }
+        }
+
+        didSet {
+            if let timer = wrappedValue, timer != oldValue {
+                RunLoop.main.add(timer, forMode: .common)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Also makes a propertyWrapper for the timer-adding runloop behavior, since it's used in a few places.