### PR TITLE
Add REST API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Added: REST API calls can now be issued.
+- Changed: `HARequestType` is now an enum of `webSocket` and `rest`. The command value for REST calls is the value after 'api/', e.g. 'api/template' has a type of `.rest(.post, "template")`.
+- Changed: `HAData` now includes a `primitive` case to express non-array/dictionary values that aren't `null`.
 
 ## [0.3] - 2021-07-08
 - Added: Subscriptions will now retry (when their request `shouldRetry`) when the HA config changes or components are loaded.

--- a/Extensions/Mocks/HAConnection+Mock.swift
+++ b/Extensions/Mocks/HAConnection+Mock.swift
@@ -156,7 +156,7 @@ public class HAMockConnection: HAConnection {
                 do {
                     completion(.success(try T(data: data)))
                 } catch {
-                    completion(.failure(.underlying(error)))
+                    completion(.failure(.underlying(error as NSError)))
                 }
             case let .failure(error):
                 completion(.failure(error))

--- a/Extensions/Mocks/HAConnection+Mock.swift
+++ b/Extensions/Mocks/HAConnection+Mock.swift
@@ -156,7 +156,7 @@ public class HAMockConnection: HAConnection {
                 do {
                     completion(.success(try T(data: data)))
                 } catch {
-                    completion(.failure(HAError.internal(debugDescription: "mock: decode failure: \(error)")))
+                    completion(.failure(.underlying(error)))
                 }
             case let .failure(error):
                 completion(.failure(error))

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # HAKit
 
-**This is still in early development.**
-
 [![Documentation](https://home-assistant.github.io/HAKit/badge.svg)](https://home-assistant.github.io/HAKit/) [![codecov](https://codecov.io/gh/home-assistant/HAKit/branch/main/graph/badge.svg?token=M0ZUCTQMBM)](https://codecov.io/gh/home-assistant/HAKit) [![License Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green.svg?style=flat)](https://github.com/home-assistant/HAKit/blob/master/LICENSE)
 
-This library allows you to connect to the [Home Assistant WebSocket API](https://developers.home-assistant.io/docs/api/websocket) to issue commands and subscribe to events. Future plans include offering minimal [REST API](https://developers.home-assistant.io/docs/api/rest) support, largely around authentication.
+This library allows you to connect to the [Home Assistant WebSocket API](https://developers.home-assistant.io/docs/api/websocket) to issue commands and subscribe to events as well as issue [REST API](https://developers.home-assistant.io/docs/api/rest) requests. Future plans include offering authentication support.
 
 ## API Reference
 
@@ -78,6 +76,16 @@ connection.send(.init(type: .currentUser, data: [:])) { result in
     // an error occurred with the request
   }
 }
+
+// you can also issue REST calls
+Current.apiConnection.send(.init(
+  // this will POST to `/api/template` with the data as the body
+  type: .rest(.post, "template"),
+  data: ["template": "{{ now() }}"]
+)) { result in
+  // same result type as sending a WebSocket request
+}
+
 ```
 
 Similarly, subscribing to events can be done both using the convenience helper or directly. 

--- a/Source/HAConnectionInfo.swift
+++ b/Source/HAConnectionInfo.swift
@@ -58,10 +58,7 @@ public struct HAConnectionInfo: Equatable {
         webSocket.request.url.map(Self.sanitize) != Self.sanitize(url)
     }
 
-    /// Create a new WebSocket connection
-    /// - Returns: The newly-created WebSocket connection
-    internal func webSocket() -> WebSocket {
-        let url = webSocketURL
+    internal func request(url: URL) -> URLRequest {
         var request = URLRequest(url: url)
 
         if let userAgent = userAgent {
@@ -78,6 +75,28 @@ public struct HAConnectionInfo: Equatable {
             }
         }
 
+        return request
+    }
+
+    internal func request(
+        path: String,
+        queryItems: [URLQueryItem]
+    ) -> URLRequest {
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        urlComponents.path = "/" + path
+
+        if !queryItems.isEmpty {
+            // providing an empty array will cause `?` to be added in all cases
+            urlComponents.queryItems = (urlComponents.queryItems ?? []) + queryItems
+        }
+
+        return request(url: urlComponents.url!)
+    }
+
+    /// Create a new WebSocket connection
+    /// - Returns: The newly-created WebSocket connection
+    internal func webSocket() -> WebSocket {
+        let request = self.request(url: webSocketURL)
         let webSocket: WebSocket
 
         if let engine = engine {

--- a/Source/HAConnectionInfo.swift
+++ b/Source/HAConnectionInfo.swift
@@ -78,6 +78,11 @@ public struct HAConnectionInfo: Equatable {
         return request
     }
 
+    /// Create a URLRequest for a given REST API path and query items
+    /// - Parameters:
+    ///   - path: The path to invoke, including the 'api/' part.
+    ///   - queryItems: The query items to include in the URL
+    /// - Returns: The URLRequest for the given parameters
     internal func request(
         path: String,
         queryItems: [URLQueryItem]

--- a/Source/HAConnectionInfo.swift
+++ b/Source/HAConnectionInfo.swift
@@ -83,7 +83,7 @@ public struct HAConnectionInfo: Equatable {
         queryItems: [URLQueryItem]
     ) -> URLRequest {
         var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)!
-        urlComponents.path = "/" + path
+        urlComponents.path += "/" + path
 
         if !queryItems.isEmpty {
             // providing an empty array will cause `?` to be added in all cases

--- a/Source/HAError.swift
+++ b/Source/HAError.swift
@@ -4,6 +4,8 @@ import Foundation
 public enum HAError: Error, Equatable, LocalizedError {
     /// An error occurred in parsing or other internal handling
     case `internal`(debugDescription: String)
+    /// An underlying error occurred, in e.g. Codable parsing or otherwise. NSError because Equatable is annoying.
+    case underlying(NSError)
     /// An error response from the server indicating a request problem
     case external(ExternalError)
 
@@ -11,6 +13,7 @@ public enum HAError: Error, Equatable, LocalizedError {
     public var errorDescription: String? {
         switch self {
         case let .external(error): return error.message
+        case let .underlying(error): return error.localizedDescription
         case let .internal(debugDescription): return debugDescription
         }
     }

--- a/Source/Internal/HAConnectionImpl+Requests.swift
+++ b/Source/Internal/HAConnectionImpl+Requests.swift
@@ -4,7 +4,7 @@ extension HAConnectionImpl: HARequestControllerDelegate {
     ) -> HARequestControllerAllowedSendKind {
         switch responseController.phase {
         case .auth, .disconnected: return .rest
-        case .command: return [.webSocket, .rest]
+        case .command: return .all
         }
     }
 

--- a/Source/Internal/HAConnectionImpl+Requests.swift
+++ b/Source/Internal/HAConnectionImpl+Requests.swift
@@ -1,8 +1,10 @@
 extension HAConnectionImpl: HARequestControllerDelegate {
-    func requestControllerShouldSendRequests(_ requestController: HARequestController) -> Bool {
+    func requestControllerAllowedSendKinds(
+        _ requestController: HARequestController
+    ) -> HARequestControllerAllowedSendKind {
         switch responseController.phase {
-        case .auth, .disconnected: return false
-        case .command: return true
+        case .auth, .disconnected: return .rest
+        case .command: return [.webSocket, .rest]
         }
     }
 

--- a/Source/Internal/HAConnectionImpl.swift
+++ b/Source/Internal/HAConnectionImpl.swift
@@ -296,7 +296,7 @@ extension HAConnectionImpl {
         // this is bad API from Apple that I don't feel like dealing with :grimace:
 
         // swiftlint:disable:next force_try
-        return try! JSONSerialization.data(withJSONObject: dictionary, options: [.sortedKeys])
+        try! JSONSerialization.data(withJSONObject: dictionary, options: [.sortedKeys])
     }
 
     private func sendWebSocket(

--- a/Source/Internal/HAConnectionImpl.swift
+++ b/Source/Internal/HAConnectionImpl.swift
@@ -341,7 +341,10 @@ extension HAConnectionImpl {
                 httpRequest.httpMethod = method.rawValue
                 httpRequest.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
                 httpRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-                httpRequest.httpBody = Self.data(from: request.data)
+
+                if method != .get, !request.data.isEmpty {
+                    httpRequest.httpBody = Self.data(from: request.data)
+                }
 
                 let task = urlSession.dataTask(with: httpRequest) { data, response, error in
                     if let response = response {

--- a/Source/Internal/HAConnectionImpl.swift
+++ b/Source/Internal/HAConnectionImpl.swift
@@ -345,7 +345,12 @@ extension HAConnectionImpl {
 
                 let task = urlSession.dataTask(with: httpRequest) { data, response, error in
                     if let response = response {
-                        responseController.didReceive(for: identifier, response: .success((response as! HTTPURLResponse, data)))
+                        responseController.didReceive(
+                            for: identifier,
+                            // This badly-typed API will always return HTTPURLResponses to http/https endpoints.
+                            // swiftlint:disable:next force_cast
+                            response: .success((response as! HTTPURLResponse, data))
+                        )
                     } else {
                         responseController.didReceive(for: identifier, response: .failure(error!))
                     }

--- a/Source/Internal/HAConnectionImpl.swift
+++ b/Source/Internal/HAConnectionImpl.swift
@@ -340,12 +340,12 @@ extension HAConnectionImpl {
                 var httpRequest = connectionInfo.request(path: "api/" + command, queryItems: request.queryItems)
                 httpRequest.httpMethod = method.rawValue
                 httpRequest.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
-                httpRequest.setValue("application/json", forHTTPHeaderField: "Content-type")
+                httpRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
                 httpRequest.httpBody = Self.data(from: request.data)
 
                 let task = urlSession.dataTask(with: httpRequest) { data, response, error in
                     if let response = response {
-                        responseController.didReceive(for: identifier, response: .success((response, data)))
+                        responseController.didReceive(for: identifier, response: .success((response as! HTTPURLResponse, data)))
                     } else {
                         responseController.didReceive(for: identifier, response: .failure(error!))
                     }

--- a/Source/Internal/RequestController/HARequestController.swift
+++ b/Source/Internal/RequestController/HARequestController.swift
@@ -1,9 +1,25 @@
 import Foundation
 
+internal struct HARequestControllerAllowedSendKind: OptionSet {
+    var rawValue: Int
+
+    static let webSocket: Self = .init(rawValue: 0b1)
+    static let rest: Self = .init(rawValue: 0b10)
+
+    func allows(requestType: HARequestType) -> Bool {
+        switch requestType {
+        case .webSocket:
+            return contains(.webSocket)
+        case .rest:
+            return contains(.rest)
+        }
+    }
+}
+
 internal protocol HARequestControllerDelegate: AnyObject {
-    func requestControllerShouldSendRequests(
+    func requestControllerAllowedSendKinds(
         _ requestController: HARequestController
-    ) -> Bool
+    ) -> HARequestControllerAllowedSendKind
     func requestController(
         _ requestController: HARequestController,
         didPrepareRequest request: HARequest,
@@ -35,6 +51,7 @@ internal class HARequestControllerImpl: HARequestController {
         var identifierGenerator = IdentifierGenerator()
         var pending: Set<HARequestInvocation> = Set()
         var active: [HARequestIdentifier: HARequestInvocation] = [:]
+        var perpetual: [HARequestIdentifier: HARequestInvocation] = [:]
 
         struct IdentifierGenerator {
             private var lastIdentifierInteger = 0
@@ -114,7 +131,7 @@ internal class HARequestControllerImpl: HARequestController {
 
     private func invocation(for identifier: HARequestIdentifier) -> HARequestInvocation? {
         state.read { state in
-            state.active[identifier]
+            state.active[identifier] ?? state.perpetual[identifier]
         }
     }
 
@@ -131,6 +148,7 @@ internal class HARequestControllerImpl: HARequestController {
         state.mutate { state in
             if let identifier = invocation.identifier {
                 state.active[identifier] = nil
+                state.perpetual[identifier] = nil
             }
 
             state.pending.remove(invocation)
@@ -171,7 +189,7 @@ internal class HARequestControllerImpl: HARequestController {
     }
 
     func prepare() {
-        guard delegate?.requestControllerShouldSendRequests(self) == true else {
+        guard let allowed = delegate?.requestControllerAllowedSendKinds(self) else {
             return
         }
 
@@ -179,10 +197,19 @@ internal class HARequestControllerImpl: HARequestController {
         var pendingCalls = [(HARequestControllerDelegate, HARequestControllerImpl) -> Void]()
 
         state.mutate { state in
-            for item in state.pending.filter(\.needsAssignment) {
+            let items = state.pending
+                .filter { $0.needsAssignment && allowed.allows(requestType: $0.request.type) }
+
+            for item in items {
                 let identifier = state.identifierGenerator.next()
-                state.active[identifier] = item
                 item.identifier = identifier
+
+                if item.request.type.isPerpetual {
+                    state.perpetual[identifier] = item
+                    state.pending.remove(item)
+                } else {
+                    state.active[identifier] = item
+                }
 
                 pendingCalls.append { delegate, controller in
                     delegate.requestController(controller, didPrepareRequest: item.request, with: identifier)

--- a/Source/Internal/RequestController/HARequestController.swift
+++ b/Source/Internal/RequestController/HARequestController.swift
@@ -5,6 +5,7 @@ internal struct HARequestControllerAllowedSendKind: OptionSet {
 
     static let webSocket: Self = .init(rawValue: 0b1)
     static let rest: Self = .init(rawValue: 0b10)
+    static let all: Self = [.webSocket, .rest]
 
     func allows(requestType: HARequestType) -> Bool {
         switch requestType {

--- a/Source/Internal/RequestController/HARequestController.swift
+++ b/Source/Internal/RequestController/HARequestController.swift
@@ -190,7 +190,7 @@ internal class HARequestControllerImpl: HARequestController {
     }
 
     func prepare() {
-        guard let allowed = delegate?.requestControllerAllowedSendKinds(self) else {
+        guard let allowed = delegate?.requestControllerAllowedSendKinds(self), !allowed.isEmpty else {
             return
         }
 

--- a/Source/Internal/ResponseController/HAResponseController.swift
+++ b/Source/Internal/ResponseController/HAResponseController.swift
@@ -163,7 +163,8 @@ internal class HAResponseControllerImpl: HAResponseController {
                         if let data = data {
                             switch urlResponse.allHeaderFields["Content-Type"] as? String {
                             case "application/json", .none:
-                                result = HAData(value: try JSONSerialization.jsonObject(with: data, options: [.allowFragments]))
+                                let value = try JSONSerialization.jsonObject(with: data, options: [.allowFragments])
+                                result = HAData(value: value)
                             default:
                                 result = HAData(value: String(data: data, encoding: .utf8))
                             }

--- a/Source/Internal/ResponseController/HAResponseController.swift
+++ b/Source/Internal/ResponseController/HAResponseController.swift
@@ -140,7 +140,7 @@ internal class HAResponseControllerImpl: HAResponseController {
 
         switch response {
         case let .failure(error):
-            didReceive.pop()?(.failure(.internal(debugDescription: error.localizedDescription)))
+            didReceive.pop()?(.failure(.underlying(error as NSError)))
         case let .success((urlResponse, data)):
             if let urlResponse = urlResponse as? HTTPURLResponse, urlResponse.statusCode >= 400 {
                 let errorMessage: String

--- a/Source/Internal/ResponseController/HAResponseController.swift
+++ b/Source/Internal/ResponseController/HAResponseController.swift
@@ -156,7 +156,7 @@ internal class HAResponseControllerImpl: HAResponseController {
                     message: errorMessage
                 ))))
             } else {
-                workQueue.async { [self] in
+                workQueue.async {
                     do {
                         let result: HAData
 

--- a/Source/Requests/HAHTTPMethod.swift
+++ b/Source/Requests/HAHTTPMethod.swift
@@ -1,0 +1,13 @@
+public struct HAHTTPMethod: RawRepresentable, Hashable, ExpressibleByStringLiteral {
+    public var rawValue: String
+    public init(rawValue: String) { self.rawValue = rawValue }
+    public init(stringLiteral value: StringLiteralType) { self.init(rawValue: value) }
+
+    public static var get: Self = "GET"
+    public static var post: Self = "POST"
+    public static var delete: Self = "DELETE"
+    public static var put: Self = "PUT"
+    public static var patch: Self = "PATCH"
+    public static var head: Self = "HEAD"
+    public static var options: Self = "OPTIONS"
+}

--- a/Source/Requests/HARequest.swift
+++ b/Source/Requests/HARequest.swift
@@ -12,7 +12,12 @@ public struct HARequest {
     ///   - data: The data to accompany with the request, at the top level
     ///   - queryItems: Query items to include in the call, for REST requests
     ///   - shouldRetry: Whether to retry the request when a connection change occurs
-    public init(type: HARequestType, data: [String: Any], queryItems: [URLQueryItem] = [], shouldRetry: Bool = true) {
+    public init(
+        type: HARequestType,
+        data: [String: Any] = [:],
+        queryItems: [URLQueryItem] = [],
+        shouldRetry: Bool = true
+    ) {
         precondition(JSONSerialization.isValidJSONObject(data))
         self.type = type
         self.data = data

--- a/Source/Requests/HARequest.swift
+++ b/Source/Requests/HARequest.swift
@@ -10,12 +10,14 @@ public struct HARequest {
     /// - Parameters:
     ///   - type: The type of the request to issue
     ///   - data: The data to accompany with the request, at the top level
+    ///   - queryItems: Query items to include in the call, for REST requests
     ///   - shouldRetry: Whether to retry the request when a connection change occurs
-    public init(type: HARequestType, data: [String: Any], shouldRetry: Bool = true) {
+    public init(type: HARequestType, data: [String: Any], queryItems: [URLQueryItem] = [], shouldRetry: Bool = true) {
         precondition(JSONSerialization.isValidJSONObject(data))
         self.type = type
         self.data = data
         self.shouldRetry = shouldRetry
+        self.queryItems = queryItems
     }
 
     /// The type of the request to be issued
@@ -24,4 +26,6 @@ public struct HARequest {
     public var data: [String: Any]
     /// Whether the request should be retried if the connection closes and reopens
     public var shouldRetry: Bool
+    /// For REST requests, any query items to include in the call
+    public var queryItems: [URLQueryItem]
 }

--- a/Source/Requests/HARequestType.swift
+++ b/Source/Requests/HARequestType.swift
@@ -19,14 +19,25 @@ public enum HARequestType: Hashable, Comparable, ExpressibleByStringLiteral {
         }
     }
 
+    /// The request is issued outside of the lifecycle of a connection
+    public var isPerpetual: Bool {
+        switch self {
+        case .webSocket: return false
+        case .rest: return true
+        }
+    }
+
     /// Sort the request type by command name
+    /// - Parameters:
+    ///   - lhs: The first type to compare
+    ///   - rhs: The second value to compare
     /// - Returns: Whether the first type preceeds the second
     public static func < (lhs: HARequestType, rhs: HARequestType) -> Bool {
         switch (lhs, rhs) {
         case (.webSocket, .rest): return true
         case (.rest, .webSocket): return false
         case let (.webSocket(lhsCommand), .webSocket(rhsCommand)),
-            let (.rest(_, lhsCommand), .rest(_, rhsCommand)):
+             let (.rest(_, lhsCommand), .rest(_, rhsCommand)):
             return lhsCommand < rhsCommand
         }
     }

--- a/Source/Requests/HARequestType.swift
+++ b/Source/Requests/HARequestType.swift
@@ -1,12 +1,34 @@
 /// The command to issue
-public struct HARequestType: RawRepresentable, Hashable, ExpressibleByStringLiteral {
-    public var rawValue: String
-    public init(rawValue: String) {
-        self.rawValue = rawValue
+public enum HARequestType: Hashable, Comparable, ExpressibleByStringLiteral {
+    /// Sent over WebSocket, the command of the request
+    case webSocket(String)
+    /// Sent over REST, the HTTP method to use and the post-`api/` path
+    case rest(HAHTTPMethod, String)
+
+    /// Create a WebSocket request type by string literal
+    /// - Parameter value: The name of the WebSocket command
+    public init(stringLiteral value: StringLiteralType) {
+        self = .webSocket(value)
     }
 
-    public init(stringLiteral value: StringLiteralType) {
-        self.init(rawValue: value)
+    /// The command of the request, agnostic of protocol type
+    public var command: String {
+        switch self {
+        case let .webSocket(command), let .rest(_, command):
+            return command
+        }
+    }
+
+    /// Sort the request type by command name
+    /// - Returns: Whether the first type preceeds the second
+    public static func < (lhs: HARequestType, rhs: HARequestType) -> Bool {
+        switch (lhs, rhs) {
+        case (.webSocket, .rest): return true
+        case (.rest, .webSocket): return false
+        case let (.webSocket(lhsCommand), .webSocket(rhsCommand)),
+            let (.rest(_, lhsCommand), .rest(_, rhsCommand)):
+            return lhsCommand < rhsCommand
+        }
     }
 
     // MARK: - Requests

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -149,7 +149,7 @@ internal class HAConnectionImplTests: XCTestCase {
             switch receivedResult {
             case let .success((receivedResponse, receivedData)):
                 XCTAssertEqual(receivedResponse.url, expectedResponse.url)
-                XCTAssertEqual((receivedResponse as? HTTPURLResponse)?.statusCode, expectedResponse.statusCode)
+                XCTAssertEqual(receivedResponse.statusCode, expectedResponse.statusCode)
                 XCTAssertEqual(receivedData, expectedData)
             default:
                 XCTFail("unexpected received result \(receivedResult)")
@@ -589,7 +589,7 @@ internal class HAConnectionImplTests: XCTestCase {
         }
     }
 
-    func testDidPrepareRequestRestSuccess() throws {
+    func testDidPrepareRequestRestSuccessJSON() throws {
         let identifier: HARequestIdentifier = 456
         let request = HARequest(
             type: .rest(.post, "some_path"),
@@ -1550,8 +1550,8 @@ private class FakeHAResponseController: HAResponseController {
     }
 
     var receivedRestWaitExpectation: XCTestExpectation?
-    var receivedRest: [Swift.Result<(URLResponse, Data?), Error>] = []
-    func didReceive(for identifier: HARequestIdentifier, response: Swift.Result<(URLResponse, Data?), Error>) {
+    var receivedRest: [Swift.Result<(HTTPURLResponse, Data?), Error>] = []
+    func didReceive(for identifier: HARequestIdentifier, response: Swift.Result<(HTTPURLResponse, Data?), Error>) {
         receivedRest.append(response)
         receivedRestWaitExpectation?.fulfill()
     }

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -471,13 +471,13 @@ internal class HAConnectionImplTests: XCTestCase {
 
     func testShouldSendRequestsDuringCommandPhase() {
         responseController.phase = .disconnected(error: nil, forReset: false)
-        XCTAssertFalse(connection.requestControllerShouldSendRequests(requestController))
+        XCTAssertEqual(connection.requestControllerAllowedSendKinds(requestController), [.rest])
 
         responseController.phase = .auth
-        XCTAssertFalse(connection.requestControllerShouldSendRequests(requestController))
+        XCTAssertEqual(connection.requestControllerAllowedSendKinds(requestController), [.rest])
 
         responseController.phase = .command(version: "")
-        XCTAssertTrue(connection.requestControllerShouldSendRequests(requestController))
+        XCTAssertEqual(connection.requestControllerAllowedSendKinds(requestController), .all)
     }
 
     func testDidPrepareRequest() throws {
@@ -899,7 +899,7 @@ internal class HAConnectionImplTests: XCTestCase {
                 case let .failure(error):
                     XCTAssertEqual(
                         error,
-                        .internal(debugDescription: String(describing: MockTypedRequestResult.DecodeError.intentional))
+                        .underlying(MockTypedRequestResult.DecodeError.intentional as NSError)
                     )
                 }
                 expectation.fulfill()
@@ -1394,11 +1394,7 @@ private class FakeHAResponseController: HAResponseController {
         received.append(event)
     }
 
-    func didReceive(
-        for identifier: HARequestIdentifier,
-        urlResponse: URLResponse?,
-        data: Data?, error: Error?
-    ) {
+    func didReceive(for identifier: HARequestIdentifier, response: Swift.Result<(URLResponse, Data?), Error>) {
         fatalError()
     }
 }

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -122,7 +122,7 @@ internal class HAConnectionImplTests: XCTestCase {
         case let .rest(method, _):
             XCTAssertEqual(sentRequest.httpMethod, method.rawValue)
             if method == .get {
-                XCTAssertNil(sentRequest.httpBodyStream)
+                XCTAssertFalse(sentRequest.httpBodyStream?.hasBytesAvailable ?? false)
             } else {
                 XCTAssertEqual(
                     String(data: sentRequest.httpBodyStreamAsData, encoding: .utf8),

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -91,7 +91,7 @@ internal class HAConnectionImplTests: XCTestCase {
                 XCTAssertEqual(jsonRep["id"] as? Int, identifier.rawValue)
             }
 
-            XCTAssertEqual(jsonRep["type"] as? String, request.type.rawValue)
+            XCTAssertEqual(jsonRep["type"] as? String, request.type.command)
 
             var copy = jsonRep
             copy["id"] = nil
@@ -1392,6 +1392,14 @@ private class FakeHAResponseController: HAResponseController {
     var received: [WebSocketEvent] = []
     func didReceive(event: WebSocketEvent) {
         received.append(event)
+    }
+
+    func didReceive(
+        for identifier: HARequestIdentifier,
+        urlResponse: URLResponse?,
+        data: Data?, error: Error?
+    ) {
+        fatalError()
     }
 }
 

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -126,7 +126,11 @@ internal class HAConnectionImplTests: XCTestCase {
         }
         XCTAssertEqual(
             String(data: sentRequest.httpBodyStreamAsData, encoding: .utf8),
-            String(data: try JSONSerialization.data(withJSONObject: request.data, options: [.sortedKeys, .fragmentsAllowed]), encoding: .utf8)
+            String(
+                data: try JSONSerialization
+                    .data(withJSONObject: request.data, options: [.sortedKeys, .fragmentsAllowed]),
+                encoding: .utf8
+            )
         )
 
         XCTAssertEqual(responseController.receivedRest.count, 1)
@@ -561,7 +565,11 @@ internal class HAConnectionImplTests: XCTestCase {
         }
 
         let identifier: HARequestIdentifier = 456
-        let request = HARequest(type: .rest(.post, "some_path"), data: ["body": true], queryItems: [.init(name: "key", value: "value")])
+        let request = HARequest(
+            type: .rest(.post, "some_path"),
+            data: ["body": true],
+            queryItems: [.init(name: "key", value: "value")]
+        )
 
         let expectation = self.expectation(description: "response received")
         responseController.receivedRestWaitExpectation = expectation
@@ -583,11 +591,18 @@ internal class HAConnectionImplTests: XCTestCase {
 
     func testDidPrepareRequestRestSuccess() throws {
         let identifier: HARequestIdentifier = 456
-        let request = HARequest(type: .rest(.post, "some_path"), data: ["body": true], queryItems: [.init(name: "key", value: "value")])
+        let request = HARequest(
+            type: .rest(.post, "some_path"),
+            data: ["body": true],
+            queryItems: [.init(name: "key", value: "value")]
+        )
 
         let requestURL = try XCTUnwrap(URL(string: XCTUnwrap(url).absoluteString + "/api/some_path?key=value"))
 
-        let expectedResult = Swift.Result<(HTTPURLResponse, Data?), Error>.success((try XCTUnwrap(HTTPURLResponse(url: requestURL, statusCode: 204, httpVersion: nil, headerFields: nil)), "response data".data(using: .utf8)))
+        let expectedResult = Swift.Result<(HTTPURLResponse, Data?), Error>.success((
+            try XCTUnwrap(HTTPURLResponse(url: requestURL, statusCode: 204, httpVersion: nil, headerFields: nil)),
+            "response data".data(using: .utf8)
+        ))
         StubbingURLProtocol.register(requestURL, result: expectedResult)
 
         let expectation = self.expectation(description: "response received")
@@ -604,7 +619,11 @@ internal class HAConnectionImplTests: XCTestCase {
 
     func testDidPrepareRequestRestNetworkingFailure() throws {
         let identifier: HARequestIdentifier = 456
-        let request = HARequest(type: .rest(.post, "some_path"), data: ["body": true], queryItems: [.init(name: "key", value: "value")])
+        let request = HARequest(
+            type: .rest(.post, "some_path"),
+            data: ["body": true],
+            queryItems: [.init(name: "key", value: "value")]
+        )
 
         let requestURL = try XCTUnwrap(URL(string: XCTUnwrap(url).absoluteString + "/api/some_path?key=value"))
 

--- a/Tests/HAData.test.swift
+++ b/Tests/HAData.test.swift
@@ -56,15 +56,19 @@ internal class HADataTests: XCTestCase {
     }
 
     func testEmpty() {
-        for value: Any? in [
-            true, 3, (), nil,
-        ] {
-            let data = HAData(value: value)
-            switch data {
-            case .empty: break // pass
-            default: XCTFail("expected empty, got \(data)")
-            }
-        }
+        XCTAssertEqual(HAData(value: nil), .empty)
+    }
+
+    func testPrimitive() {
+        XCTAssertEqual(HAData(value: 3), .primitive(3))
+        XCTAssertNotEqual(HAData(value: 3), .primitive("other"))
+        XCTAssertEqual(HAData(value: "test"), .primitive("test"))
+        XCTAssertNotEqual(HAData(value: "test"), .primitive(-1))
+        XCTAssertEqual(HAData(value: 3.0), .primitive(3.0))
+        XCTAssertNotEqual(HAData(value: 3.0), .primitive("other"))
+        XCTAssertEqual(HAData(value: true), .primitive(true))
+        XCTAssertNotEqual(HAData(value: true), .primitive("other"))
+        XCTAssertEqual(HAData(value: false), .primitive(false))
     }
 
     func testDecodeMissingKey() {
@@ -126,10 +130,10 @@ internal class HADataTests: XCTestCase {
         let value = HAData(value: ["key": ["a": true, "b": ["test": true]]])
         let keyValue: [String: HAData] = try value.decode("key")
 
-        if case .empty = keyValue["a"] {
-            // pass
+        if case let .primitive(primitiveValue) = keyValue["a"] {
+            XCTAssertEqual(primitiveValue as? Bool, true)
         } else {
-            XCTFail("expected empty but got \(String(describing: keyValue["a"]))")
+            XCTFail("expected primitive but got \(String(describing: keyValue["a"]))")
         }
 
         if case let .dictionary(dictionary) = keyValue["b"] {

--- a/Tests/HAError.test.swift
+++ b/Tests/HAError.test.swift
@@ -8,6 +8,10 @@ internal class HAErrorTests: XCTestCase {
 
         let error2 = HAError.external(.init(code: "code", message: "msg2"))
         XCTAssertEqual(error2.localizedDescription, "msg2")
+
+        let underlying = NSError(domain: "test", code: 123, userInfo: [:])
+        let error3 = HAError.underlying(underlying)
+        XCTAssertEqual(error3.localizedDescription, underlying.localizedDescription)
     }
 
     func testExternalErrorInitWithBad() {

--- a/Tests/HARequestController.test.swift
+++ b/Tests/HARequestController.test.swift
@@ -20,14 +20,14 @@ internal class HARequestControllerTests: XCTestCase {
         XCTAssertTrue(delegate.didPrepare.isEmpty)
 
         // transition to allowed
-        delegate.shouldSendRequests = true
+        delegate.allowedSendKinds = .all
 
         controller.prepare()
         XCTAssertFalse(delegate.didPrepare.isEmpty)
     }
 
     func testAddingWhenAllowed() throws {
-        delegate.shouldSendRequests = true
+        delegate.allowedSendKinds = .all
 
         controller.add(.init(request: .init(type: "test1", data: [:])))
         controller.add(.init(request: .init(type: "test2", data: [:])))
@@ -53,7 +53,7 @@ internal class HARequestControllerTests: XCTestCase {
     }
 
     func testAddedAndResetActive() throws {
-        delegate.shouldSendRequests = true
+        delegate.allowedSendKinds = .all
 
         // will completed
         let invoc1 = HARequestInvocationSingle(
@@ -115,14 +115,14 @@ internal class HARequestControllerTests: XCTestCase {
 
         XCTAssertFalse(invocation.needsAssignment)
 
-        delegate.shouldSendRequests = true
+        delegate.allowedSendKinds = .all
         controller.prepare()
 
         XCTAssertTrue(delegate.didPrepare.isEmpty)
     }
 
     func testCancelSingleAfterSent() {
-        delegate.shouldSendRequests = true
+        delegate.allowedSendKinds = .all
 
         var didCallCompletion = false
 
@@ -157,14 +157,14 @@ internal class HARequestControllerTests: XCTestCase {
 
         XCTAssertFalse(invocation.needsAssignment)
 
-        delegate.shouldSendRequests = true
+        delegate.allowedSendKinds = .all
         controller.prepare()
 
         XCTAssertTrue(delegate.didPrepare.isEmpty)
     }
 
     func testCancelSubscriptionAfterSent() throws {
-        delegate.shouldSendRequests = true
+        delegate.allowedSendKinds = .all
 
         let invocation = HARequestInvocationSubscription(
             request: .init(type: "test1", data: [:]),
@@ -191,7 +191,7 @@ internal class HARequestControllerTests: XCTestCase {
     }
 
     func testClearSingle() {
-        delegate.shouldSendRequests = true
+        delegate.allowedSendKinds = .all
 
         let invocation = HARequestInvocationSingle(
             request: .init(type: "test1", data: [:]),
@@ -233,7 +233,7 @@ internal class HARequestControllerTests: XCTestCase {
             handler: { _, _ in }
         )
 
-        delegate.shouldSendRequests = true
+        delegate.allowedSendKinds = .all
         controller.add(invocation1)
         controller.add(invocation2)
         controller.add(invocation3)
@@ -283,10 +283,10 @@ internal class HARequestControllerTests: XCTestCase {
 }
 
 private class TestHARequestControllerDelegate: HARequestControllerDelegate {
-    var shouldSendRequests = false
+    var allowedSendKinds: HARequestControllerAllowedSendKind = []
 
-    func requestControllerShouldSendRequests(_ requestController: HARequestController) -> Bool {
-        shouldSendRequests
+    func requestControllerAllowedSendKinds(_ requestController: HARequestController) -> HARequestControllerAllowedSendKind {
+        allowedSendKinds
     }
 
     var didPrepare: [(request: HARequest, identifier: HARequestIdentifier)] = []

--- a/Tests/HARequestController.test.swift
+++ b/Tests/HARequestController.test.swift
@@ -37,7 +37,7 @@ internal class HARequestControllerTests: XCTestCase {
             try delegate.didPrepare.get(throwing: 0),
             try delegate.didPrepare.get(throwing: 1),
         ].sorted(by: { lhs, rhs in
-            lhs.request.type.rawValue < rhs.request.type.rawValue
+            lhs.request.type < rhs.request.type
         })
 
         let event1 = allEvents[0]
@@ -45,10 +45,10 @@ internal class HARequestControllerTests: XCTestCase {
 
         XCTAssertNotEqual(event1.identifier.rawValue, event2.identifier.rawValue)
 
-        XCTAssertEqual(event1.request.type.rawValue, "test1")
+        XCTAssertEqual(event1.request.type.command, "test1")
         XCTAssertGreaterThan(event1.identifier.rawValue, 0)
 
-        XCTAssertEqual(event2.request.type.rawValue, "test2")
+        XCTAssertEqual(event2.request.type.command, "test2")
         XCTAssertGreaterThan(event2.identifier.rawValue, 0)
     }
 
@@ -100,7 +100,7 @@ internal class HARequestControllerTests: XCTestCase {
         controller.prepare()
         XCTAssertEqual(delegate.didPrepare.count, 2)
 
-        let types = Set(delegate.didPrepare.map(\.request.type.rawValue))
+        let types = Set(delegate.didPrepare.map(\.request.type.command))
         XCTAssertEqual(types, Set(["test3", "test4"]))
     }
 
@@ -276,7 +276,7 @@ internal class HARequestControllerTests: XCTestCase {
         XCTAssertNil(controller.retrySubscriptionsTimer)
 
         XCTAssertEqual(
-            Set(delegate.didPrepare.map(\.request.type.rawValue)),
+            Set(delegate.didPrepare.map(\.request.type.command)),
             Set(["try1", "try2"])
         )
     }

--- a/Tests/HARequestController.test.swift
+++ b/Tests/HARequestController.test.swift
@@ -134,7 +134,6 @@ internal class HARequestControllerTests: XCTestCase {
 
         let types = Set(delegate.didPrepare.map(\.request.type.command))
         XCTAssertEqual(types, Set(["test2"]))
-
     }
 
     func testAddedAndResetActive() throws {
@@ -370,7 +369,8 @@ internal class HARequestControllerTests: XCTestCase {
 private class TestHARequestControllerDelegate: HARequestControllerDelegate {
     var allowedSendKinds: HARequestControllerAllowedSendKind = []
 
-    func requestControllerAllowedSendKinds(_ requestController: HARequestController) -> HARequestControllerAllowedSendKind {
+    func requestControllerAllowedSendKinds(_ requestController: HARequestController)
+        -> HARequestControllerAllowedSendKind {
         allowedSendKinds
     }
 

--- a/Tests/HAResponseController.test.swift
+++ b/Tests/HAResponseController.test.swift
@@ -132,6 +132,53 @@ internal class HAResponseControllerTests: XCTestCase {
             expectingPhase: commandPhase
         )
     }
+
+    func testRestResponseFailure() throws {
+        enum FakeError: Error {
+            case error
+        }
+        controller.didReceive(for: 456, response: .failure(FakeError.error))
+        XCTAssertEqual(delegate.lastReceived, .result(identifier: 456, result: .failure(.underlying(FakeError.error as NSError))))
+    }
+
+    func testRestResponse4xx() throws {
+        let response = try XCTUnwrap(HTTPURLResponse(url: URL(string: "http://example.com")!, statusCode: 401, httpVersion: nil, headerFields: nil))
+        let dataString = "error msg"
+        controller.didReceive(for: 888, response: .success((response, dataString.data(using: .utf8))))
+        XCTAssertEqual(delegate.lastReceived, .result(identifier: 888, result: .failure(.external(.init(code: "401", message: dataString)))))
+
+        controller.didReceive(for: 888, response: .success((response, nil)))
+        XCTAssertEqual(delegate.lastReceived, .result(identifier: 888, result: .failure(.external(.init(code: "401", message: "Unacceptable status code")))))
+    }
+
+    func testRestResponseSuccess() throws {
+        let response = try XCTUnwrap(HTTPURLResponse(url: URL(string: "http://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil))
+
+        controller.didReceive(for: 1, response: .success((response, nil)))
+        waitForCallback()
+        XCTAssertEqual(delegate.lastReceived, .result(identifier: 1, result: .success(.empty)))
+
+        delegate.lastReceived = nil
+
+        let resultDictionary = ["test": true]
+        controller.didReceive(for: 2, response: .success((response, try JSONSerialization.data(withJSONObject: resultDictionary, options: []))))
+        waitForCallback()
+        XCTAssertEqual(delegate.lastReceived, .result(identifier: 2, result: .success(.dictionary(resultDictionary))))
+
+        delegate.lastReceived = nil
+
+        let invalidJson = "{".data(using: .utf8)
+        controller.didReceive(for: 3, response: .success((response, invalidJson)))
+        waitForCallback()
+
+        switch delegate.lastReceived {
+        case .result(identifier: 3, result: .failure(.underlying(_))):
+            // pass
+            break
+        default:
+            XCTFail("expected error response")
+        }
+    }
 }
 
 private extension HAResponseControllerTests {

--- a/Tests/HAResponseController.test.swift
+++ b/Tests/HAResponseController.test.swift
@@ -138,21 +138,45 @@ internal class HAResponseControllerTests: XCTestCase {
             case error
         }
         controller.didReceive(for: 456, response: .failure(FakeError.error))
-        XCTAssertEqual(delegate.lastReceived, .result(identifier: 456, result: .failure(.underlying(FakeError.error as NSError))))
+        XCTAssertEqual(
+            delegate.lastReceived,
+            .result(identifier: 456, result: .failure(.underlying(FakeError.error as NSError)))
+        )
     }
 
     func testRestResponse4xx() throws {
-        let response = try XCTUnwrap(HTTPURLResponse(url: URL(string: "http://example.com")!, statusCode: 401, httpVersion: nil, headerFields: nil))
+        let response =
+            try XCTUnwrap(HTTPURLResponse(
+                url: URL(string: "http://example.com")!,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: nil
+            ))
         let dataString = "error msg"
         controller.didReceive(for: 888, response: .success((response, dataString.data(using: .utf8))))
-        XCTAssertEqual(delegate.lastReceived, .result(identifier: 888, result: .failure(.external(.init(code: "401", message: dataString)))))
+        XCTAssertEqual(
+            delegate.lastReceived,
+            .result(identifier: 888, result: .failure(.external(.init(code: "401", message: dataString))))
+        )
 
         controller.didReceive(for: 888, response: .success((response, nil)))
-        XCTAssertEqual(delegate.lastReceived, .result(identifier: 888, result: .failure(.external(.init(code: "401", message: "Unacceptable status code")))))
+        XCTAssertEqual(
+            delegate.lastReceived,
+            .result(
+                identifier: 888,
+                result: .failure(.external(.init(code: "401", message: "Unacceptable status code")))
+            )
+        )
     }
 
     func testRestResponseSuccess() throws {
-        let response = try XCTUnwrap(HTTPURLResponse(url: URL(string: "http://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil))
+        let response =
+            try XCTUnwrap(HTTPURLResponse(
+                url: URL(string: "http://example.com")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            ))
 
         controller.didReceive(for: 1, response: .success((response, nil)))
         waitForCallback()
@@ -161,7 +185,10 @@ internal class HAResponseControllerTests: XCTestCase {
         delegate.lastReceived = nil
 
         let resultDictionary = ["test": true]
-        controller.didReceive(for: 2, response: .success((response, try JSONSerialization.data(withJSONObject: resultDictionary, options: []))))
+        controller.didReceive(
+            for: 2,
+            response: .success((response, try JSONSerialization.data(withJSONObject: resultDictionary, options: [])))
+        )
         waitForCallback()
         XCTAssertEqual(delegate.lastReceived, .result(identifier: 2, result: .success(.dictionary(resultDictionary))))
 

--- a/Tests/HAResponseController.test.swift
+++ b/Tests/HAResponseController.test.swift
@@ -231,9 +231,15 @@ internal class HAResponseControllerTests: XCTestCase {
 
         delegate.lastReceived = nil
 
-        controller.didReceive(for: 5, response: .success((responseNoHeader, invalidJson)))
+        controller.didReceive(
+            for: 2,
+            response: .success((
+                responseNoHeader,
+                try JSONSerialization.data(withJSONObject: resultDictionary, options: [])
+            ))
+        )
         waitForCallback()
-        XCTAssertEqual(delegate.lastReceived, .result(identifier: 5, result: .success(.primitive("{"))))
+        XCTAssertEqual(delegate.lastReceived, .result(identifier: 2, result: .success(.dictionary(resultDictionary))))
     }
 }
 

--- a/Tests/HAResponseController.test.swift
+++ b/Tests/HAResponseController.test.swift
@@ -201,7 +201,10 @@ internal class HAResponseControllerTests: XCTestCase {
         let resultDictionary = ["test": true]
         controller.didReceive(
             for: 2,
-            response: .success((responseJSON, try JSONSerialization.data(withJSONObject: resultDictionary, options: [])))
+            response: .success((
+                responseJSON,
+                try JSONSerialization.data(withJSONObject: resultDictionary, options: [])
+            ))
         )
         waitForCallback()
         XCTAssertEqual(delegate.lastReceived, .result(identifier: 2, result: .success(.dictionary(resultDictionary))))

--- a/Tests/StubbingURLProtocol.swift
+++ b/Tests/StubbingURLProtocol.swift
@@ -1,0 +1,53 @@
+import Foundation
+import XCTest
+
+class StubbingURLProtocol: URLProtocol {
+    typealias PendingResult = Result<(HTTPURLResponse, Data?), Error>
+    private static var pending = [URL: PendingResult]()
+    static var received = [URL: URLRequest]()
+
+    class func register(
+        _ url: URL,
+        result: PendingResult
+    ) {
+        pending[url] = result
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url != nil
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        // default implementation asserts
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url, let result = Self.pending.removeValue(forKey: url) else {
+            XCTFail("unexpected request: \(request)")
+            return
+        }
+
+        guard let client = client else {
+            XCTFail("unable to complete")
+            return
+        }
+
+        Self.received[url] = request
+
+        switch result {
+        case let .success((response, data)):
+            client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data = data {
+                client.urlProtocol(self, didLoad: data)
+            }
+            client.urlProtocolDidFinishLoading(self)
+        case let .failure(error):
+            client.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {
+        
+    }
+}

--- a/Tests/StubbingURLProtocol.swift
+++ b/Tests/StubbingURLProtocol.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-class StubbingURLProtocol: URLProtocol {
+internal class StubbingURLProtocol: URLProtocol {
     typealias PendingResult = Result<(HTTPURLResponse, Data?), Error>
     private static var pending = [URL: PendingResult]()
     static var received = [URL: URLRequest]()
@@ -47,7 +47,5 @@ class StubbingURLProtocol: URLProtocol {
         }
     }
 
-    override func stopLoading() {
-        
-    }
+    override func stopLoading() {}
 }


### PR DESCRIPTION
Allow sending REST requests in the same flow as sending a WebSocket request. REST requests are sent outside of the WebSocket connection lifecycle. Most REST responses are JSON, but some are raw strings, and this is handled via Content-Type.

Adds support for HAData to wrap non-dictionary/array/empty values, since top-level REST responses can include things like strings.