### PR TITLE
Fix a few threading issues/crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: REST API calls can now be issued.
 - Changed: `HARequestType` is now an enum of `webSocket` and `rest`. The command value for REST calls is the value after 'api/', e.g. 'api/template' has a type of `.rest(.post, "template")`.
 - Changed: `HAData` now includes a `primitive` case to express non-array/dictionary values that aren't `null`.
+- Fixed: Calling `HAConnection.connect()` and `HAConnection.disconnect()` off the main thread no longer occasionally crashes.
 
 ## [0.3] - 2021-07-08
 - Added: Subscriptions will now retry (when their request `shouldRetry`) when the HA config changes or components are loaded.

--- a/Source/Internal/HAReconnectManager.swift
+++ b/Source/Internal/HAReconnectManager.swift
@@ -67,6 +67,7 @@ internal class HAReconnectManagerImpl: HAReconnectManager {
                 nextTimerDate = reconnectTimer?.fireDate
             }
         }
+
         var lastPingDuration: Measurement<UnitDuration>?
         @HASchedulingTimer var pingTimer: Timer?
 
@@ -78,6 +79,7 @@ internal class HAReconnectManagerImpl: HAReconnectManager {
             retryCount = 0
         }
     }
+
     private let state = HAProtected<State>(value: .init())
 
     var reason: HAConnectionState.DisconnectReason {
@@ -229,12 +231,15 @@ extension HAReconnectManagerImpl {
     var reconnectTimer: Timer? {
         state.read(\.reconnectTimer)
     }
+
     var lastPingDuration: Measurement<UnitDuration>? {
         state.read(\.lastPingDuration)
     }
+
     var pingTimer: Timer? {
         state.read(\.pingTimer)
     }
+
     var retryCount: Int {
         state.read(\.retryCount)
     }


### PR DESCRIPTION
- Fixes a few threading issues around connect/disconnect happening off the main thread, by instead async doing the change.
- Fixes some issues where ping timers were created/destroyed simultaneously on different threads nonatomically which caused crashes in CFRelease of the underlying timer.