### PR TITLE
Allow validating certificates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ on:
       - main
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_13.3.1.app/Contents/Developer
   HOMEBREW_NO_INSTALL_CLEANUP: TRUE
 
 jobs:
   lint:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
@@ -21,7 +21,7 @@ jobs:
         run: make lint
 
   test:
-    runs-on: macos-latest
+    runs-on: macos-12
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2

--- a/Source/Internal/HAConnectionImpl.swift
+++ b/Source/Internal/HAConnectionImpl.swift
@@ -362,7 +362,7 @@ extension HAConnectionImpl {
                     httpRequest.httpBody = Self.data(from: request.data)
                 }
 
-                let task = urlSession.dataTask(with: httpRequest) { data, response, error in
+                let task = urlSession.dataTask(with: httpRequest) { [self] data, response, error in
                     if let response = response {
                         responseController.didReceive(
                             for: identifier,

--- a/Source/Internal/HAStarscreamCertificatePinningImpl.swift
+++ b/Source/Internal/HAStarscreamCertificatePinningImpl.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Starscream
+
+internal class HAStarscreamCertificatePinningImpl: CertificatePinning {
+    let evaluateCertificate: HAConnectionInfo.EvaluateCertificate
+    init(evaluateCertificate: @escaping HAConnectionInfo.EvaluateCertificate) {
+        self.evaluateCertificate = evaluateCertificate
+    }
+
+    func evaluateTrust(trust: SecTrust, domain: String?, completion: (PinningState) -> Void) {
+        evaluateCertificate(trust, {
+            switch $0 {
+            case .success:
+                completion(.success)
+            case let .failure(error):
+                // although it looks like it would always succeed, a Swift Error may not be convertable here
+                completion(.failed(error as? CFError? ?? CFErrorCreate(nil, "UnknownSSL" as CFErrorDomain, 1, nil)))
+            }
+        })
+    }
+}

--- a/Source/Internal/ResponseController/HAResponseController.swift
+++ b/Source/Internal/ResponseController/HAResponseController.swift
@@ -100,7 +100,7 @@ internal class HAResponseControllerImpl: HAResponseController {
                     }
                 }
 
-                DispatchQueue.main.async {
+                DispatchQueue.main.async { [self] in
                     if case let .auth(.ok(version)) = response {
                         phase = .command(version: version)
                     }

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -57,7 +57,7 @@ internal class HAConnectionImplTests: XCTestCase {
         connection = .init(
             configuration: .init(connectionInfo: { [weak self] in
                 if let url = self?.url, let engine = self?.engine {
-                    return try? .init(url: url, userAgent: nil, engine: engine)
+                    return try? .init(url: url, userAgent: nil, evaluateCertificate: nil, engine: engine)
                 } else {
                     XCTAssertNotNil(self?.engine, "invoked after deallocated")
                     return nil

--- a/Tests/HAConnectionInfo.test.swift
+++ b/Tests/HAConnectionInfo.test.swift
@@ -34,7 +34,7 @@ internal class HAConnectionInfoTests: XCTestCase {
         let engine1 = FakeEngine()
         let engine2 = FakeEngine()
 
-        let connectionInfo = try HAConnectionInfo(url: url, userAgent: nil, engine: engine1)
+        let connectionInfo = try HAConnectionInfo(url: url, userAgent: nil, evaluateCertificate: nil, engine: engine1)
         XCTAssertEqual(connectionInfo.url, url)
         XCTAssertEqual(ObjectIdentifier(connectionInfo.engine as AnyObject), ObjectIdentifier(engine1))
 
@@ -49,7 +49,12 @@ internal class HAConnectionInfoTests: XCTestCase {
         // just engine difference isn't enough (since we can't tell)
         XCTAssertFalse(connectionInfoWithoutEngine.shouldReplace(webSocket))
 
-        let connectionInfoWithDifferentEngine = try HAConnectionInfo(url: url, userAgent: nil, engine: engine2)
+        let connectionInfoWithDifferentEngine = try HAConnectionInfo(
+            url: url,
+            userAgent: nil,
+            evaluateCertificate: nil,
+            engine: engine2
+        )
         XCTAssertFalse(connectionInfoWithDifferentEngine.shouldReplace(webSocket))
     }
 
@@ -112,13 +117,88 @@ internal class HAConnectionInfoTests: XCTestCase {
         }
     }
 
+    func testCreationWithCertificateEvaluation() throws {
+        var result: Result<Void, Error> = .success(())
+
+        let url = URL(string: "http://example.com")!
+        let connectionInfo = try HAConnectionInfo(url: url, evaluateCertificate: {
+            $1(result)
+        })
+        XCTAssertEqual(connectionInfo.url, url)
+
+        // not easy to test WebSocket, so we test our wrapper for it
+        let pinning = HAStarscreamCertificatePinningImpl(
+            evaluateCertificate: try XCTUnwrap(connectionInfo.evaluateCertificate)
+        )
+
+        var secTrust: SecTrust?
+        SecTrustCreateWithCertificates([
+            try XCTUnwrap(SecCertificateCreateWithData(nil, XCTUnwrap(Data(base64Encoded: """
+                MIIFljCCA36gAwIBAgINAgO8U1lrNMcY9QFQZjANBgkqhkiG9w0BAQsFADBHMQswCQYDVQQGEwJVUzEiMCAGA1UEChMZR29vZ2xlIFRy
+                dXN0IFNlcnZpY2VzIExMQzEUMBIGA1UEAxMLR1RTIFJvb3QgUjEwHhcNMjAwODEzMDAwMDQyWhcNMjcwOTMwMDAwMDQyWjBGMQswCQYD
+                VQQGEwJVUzEiMCAGA1UEChMZR29vZ2xlIFRydXN0IFNlcnZpY2VzIExMQzETMBEGA1UEAxMKR1RTIENBIDFDMzCCASIwDQYJKoZIhvcN
+                AQEBBQADggEPADCCAQoCggEBAPWI3+dijB43+DdCkH9sh9D7ZYIl/ejLa6T/belaI+KZ9hzpkgOZE3wJCor6QtZeViSqejOEH9Hpabu5
+                dOxXTGZok3c3VVP+ORBNtzS7XyV3NzsXlOo85Z3VvMO0Q+sup0fvsEQRY9i0QYXdQTBIkxu/t/bgRQIh4JZCF8/ZK2VWNAcmBA2o/X3K
+                Lu/qSHw3TT8An4Pf73WELnlXXPxXbhqW//yMmqaZviXZf5YsBvcRKgKAgOtjGDxQSYflispfGStZloEAoPtR28p3CwvJlk/vcEnHXG0g
+                /Zm0tOLKLnf9LdwLtmsTDIwZKxeWmLnwi/agJ7u2441Rj72ux5uxiZ0CAwEAAaOCAYAwggF8MA4GA1UdDwEB/wQEAwIBhjAdBgNVHSUE
+                FjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQUinR/r4XN7pXNPZzQ4kYU83E1HScwHwYD
+                VR0jBBgwFoAU5K8rJnEaK0gnhS9SZizv8IkTcT4waAYIKwYBBQUHAQEEXDBaMCYGCCsGAQUFBzABhhpodHRwOi8vb2NzcC5wa2kuZ29v
+                Zy9ndHNyMTAwBggrBgEFBQcwAoYkaHR0cDovL3BraS5nb29nL3JlcG8vY2VydHMvZ3RzcjEuZGVyMDQGA1UdHwQtMCswKaAnoCWGI2h0
+                dHA6Ly9jcmwucGtpLmdvb2cvZ3RzcjEvZ3RzcjEuY3JsMFcGA1UdIARQME4wOAYKKwYBBAHWeQIFAzAqMCgGCCsGAQUFBwIBFhxodHRw
+                czovL3BraS5nb29nL3JlcG9zaXRvcnkvMAgGBmeBDAECATAIBgZngQwBAgIwDQYJKoZIhvcNAQELBQADggIBAIl9rCBcDDy+mqhXlRu0
+                rvqrpXJxtDaV/d9AEQNMwkYUuxQkq/BQcSLbrcRuf8/xam/IgxvYzolfh2yHuKkMo5uhYpSTld9brmYZCwKWnvy15xBpPnrLRklfRuFB
+                sdeYTWU0AIAaP0+fbH9JAIFTQaSSIYKCGvGjRFsqUBITTcFTNvNCCK9U+o53UxtkOCcXCb1YyRt8OS1b887U7ZfbFAO/CVMkH8IMBHmY
+                JvJh8VNS/UKMG2YrPxWhu//2m+OBmgEGcYk1KCTd4b3rGS3hSMs9WYNRtHTGnXzGsYZbr8w0xNPM1IERlQCh9BIiAfq0g3GvjLeMcySs
+                N1PCAJA/Ef5c7TaUEDu9Ka7ixzpiO2xj2YC/WXGsYye5TBeg2vZzFb8q3o/zpWwygTMD0IZRcZk0upONXbVRWPeyk+gB9lm+cZv9TSjO
+                z23HFtz30dZGm6fKa+l3D/2gthsjgx0QGtkJAITgRNOidSOzNIb2ILCkXhAd4FJGAJ2xDx8hcFH1mt0G/FX0Kw4zd8NLQsLxdxP8c4CU
+                6x+7Nz/OAipmsHMdMqUybDKwjuDEI/9bfU1lcKwrmz3O2+BtjjKAvpafkmO8l7tdufThcV4q5O8DIrGKZTqPwJNl1IXNDw9bg1kWRxYt
+                nCQ6yICmJhSFm/Y3m6xv+cXDBlHz4n/FsRC6UfTd
+            """, options: [.ignoreUnknownCharacters])) as CFData)),
+        ] as CFArray, SecPolicyCreateBasicX509(), &secTrust)
+        guard let secTrust = secTrust else {
+            XCTFail("couldn't construct certificate")
+            return
+        }
+
+        let expectation1 = expectation(description: "first request")
+        pinning.evaluateTrust(trust: secTrust, domain: "some_domain") { pinningState in
+            switch pinningState {
+            case .success:
+                // pass
+                break
+            case .failed:
+                XCTFail("expected success, got failure")
+            }
+            expectation1.fulfill()
+        }
+        wait(for: [expectation1], timeout: 10.0)
+
+        enum TestError: Error {
+            case any
+        }
+        result = .failure(TestError.any)
+
+        let expectation2 = expectation(description: "second request")
+        pinning.evaluateTrust(trust: secTrust, domain: "some_domain") { pinningState in
+            switch pinningState {
+            case .success:
+                XCTFail("expected failure, got success")
+            case .failed:
+                // pass
+                break
+            }
+            expectation2.fulfill()
+        }
+        wait(for: [expectation2], timeout: 10.0)
+    }
+
     func testShouldReplace() throws {
         let url1 = URL(string: "http://example.com/1")!
         let url2 = URL(string: "http://example.com/2")!
         let engine = FakeEngine()
 
-        let connectionInfo1 = try HAConnectionInfo(url: url1, userAgent: nil, engine: engine)
-        let connectionInfo2 = try HAConnectionInfo(url: url2, userAgent: nil, engine: engine)
+        let connectionInfo1 = try HAConnectionInfo(url: url1, userAgent: nil, evaluateCertificate: nil, engine: engine)
+        let connectionInfo2 = try HAConnectionInfo(url: url2, userAgent: nil, evaluateCertificate: nil, engine: engine)
 
         let webSocket1 = connectionInfo1.webSocket()
         XCTAssertFalse(connectionInfo1.shouldReplace(webSocket1))


### PR DESCRIPTION
To allow the HA app to handle invalid certs, allow the connection info to be constructed to decide whether a connection should be allowed.