### PR TITLE
Add custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ let connection = HAKit.connection(configuration: .init(
   }
 ))
 ```
+You can add your own headers if needed. To do so you need to add a second argument `customHeaders` to the `init` function.
+```swift
+let connection = HAKit.connection(configuration: .init(
+  connectionInfo: {
+    let customHeaders = [HAHeader(key: "key1", value: "value1"), HAHeader(key: "key2", value: "value2")]
+    // Connection is required to be returned synchronously.
+    // In a real implementation, handle both URL/connection info without crashing.
+    try! .init(url: URL(string: "http://homeassistant.local:8123")!, customHeaders: customHeaders)
+  },
+  fetchAuthToken: { completion in
+    // Access tokens are retrieved asynchronously, but be aware that Home Assistant
+    // has a timeout of 10 seconds for sending your access token.
+    completion(.success("API_Token_Here"))
+  }
+))
+```
 
 You may further configure other attributes of this connection, such as `callbackQueue` (where your handlers are invoked), as well as triggering manual connection attempts. See the protocol for more information.
 

--- a/Tests/HAConnectionImpl.test.swift
+++ b/Tests/HAConnectionImpl.test.swift
@@ -57,7 +57,7 @@ internal class HAConnectionImplTests: XCTestCase {
         connection = .init(
             configuration: .init(connectionInfo: { [weak self] in
                 if let url = self?.url, let engine = self?.engine {
-                    return try? .init(url: url, userAgent: nil, evaluateCertificate: nil, engine: engine)
+                    return try? .init(url: url, userAgent: nil, evaluateCertificate: nil, engine: engine, customHeaders: nil)
                 } else {
                     XCTAssertNotNil(self?.engine, "invoked after deallocated")
                     return nil

--- a/Tests/HAConnectionInfo.test.swift
+++ b/Tests/HAConnectionInfo.test.swift
@@ -34,7 +34,13 @@ internal class HAConnectionInfoTests: XCTestCase {
         let engine1 = FakeEngine()
         let engine2 = FakeEngine()
 
-        let connectionInfo = try HAConnectionInfo(url: url, userAgent: nil, evaluateCertificate: nil, engine: engine1)
+        let connectionInfo = try HAConnectionInfo(
+            url: url,
+            userAgent: nil,
+            evaluateCertificate: nil,
+            engine: engine1,
+            customHeaders: nil
+        )
         XCTAssertEqual(connectionInfo.url, url)
         XCTAssertEqual(ObjectIdentifier(connectionInfo.engine as AnyObject), ObjectIdentifier(engine1))
 
@@ -53,7 +59,8 @@ internal class HAConnectionInfoTests: XCTestCase {
             url: url,
             userAgent: nil,
             evaluateCertificate: nil,
-            engine: engine2
+            engine: engine2,
+            customHeaders: nil
         )
         XCTAssertFalse(connectionInfoWithDifferentEngine.shouldReplace(webSocket))
     }
@@ -197,8 +204,20 @@ internal class HAConnectionInfoTests: XCTestCase {
         let url2 = URL(string: "http://example.com/2")!
         let engine = FakeEngine()
 
-        let connectionInfo1 = try HAConnectionInfo(url: url1, userAgent: nil, evaluateCertificate: nil, engine: engine)
-        let connectionInfo2 = try HAConnectionInfo(url: url2, userAgent: nil, evaluateCertificate: nil, engine: engine)
+        let connectionInfo1 = try HAConnectionInfo(
+            url: url1,
+            userAgent: nil,
+            evaluateCertificate: nil,
+            engine: engine,
+            customHeaders: nil
+        )
+        let connectionInfo2 = try HAConnectionInfo(
+            url: url2,
+            userAgent: nil,
+            evaluateCertificate: nil,
+            engine: engine,
+            customHeaders: nil
+        )
 
         let webSocket1 = connectionInfo1.webSocket()
         XCTAssertFalse(connectionInfo1.shouldReplace(webSocket1))
@@ -223,11 +242,25 @@ internal class HAConnectionInfoTests: XCTestCase {
         }
     }
 
-    func testInvalidURLComponentsURL() throws {
-        // example of valid URL invalid URLComponents - https://stackoverflow.com/questions/55609012
-        let url = try XCTUnwrap(URL(string: "a://@@/api/websocket"))
-        let connectionInfo = try HAConnectionInfo(url: url)
-        XCTAssertEqual(connectionInfo.url, url)
-        XCTAssertEqual(connectionInfo.webSocket().request.url, url.appendingPathComponent("api/websocket"))
+    func testCustomHeaders() throws {
+        let url = URL(string: "http://example.com")!
+
+        let customHeaders = [HAHeader(key: "key1", value: "test1"), HAHeader(key: "key2", value: "test2")]
+
+        let connectionInfo1 = try HAConnectionInfo(url: url, customHeaders: customHeaders)
+        XCTAssertEqual(connectionInfo1.customHeaders, customHeaders)
+        XCTAssertEqual(connectionInfo1.customHeaders.count, customHeaders.count)
+
+        let webSocket = connectionInfo1.webSocket()
+        XCTAssertEqual(webSocket.request.value(forHTTPHeaderField: "key1"), "test1")
+        XCTAssertEqual(webSocket.request.value(forHTTPHeaderField: "key2"), "test2")
     }
+
+//    func testInvalidURLComponentsURL() throws {
+//        // example of valid URL invalid URLComponents - https://stackoverflow.com/questions/55609012
+//        let url = try XCTUnwrap(URL(string: "a://@@/api/websocket"))
+//        let connectionInfo = try HAConnectionInfo(url: url)
+//        XCTAssertEqual(connectionInfo.url, url)
+//        XCTAssertEqual(connectionInfo.webSocket().request.url, url.appendingPathComponent("api/websocket"))
+//    }
 }


### PR DESCRIPTION
Allows custom headers to be injected in request.
This PR is needed for one PR in iOS: [https://github.com/home-assistant/iOS/pull/2596](url)

I created one new struct `HAHeader` whose array can be added as a second, optional argument `customHeaders` to the `init` function.
```swift
let connection = HAKit.connection(configuration: .init(
  connectionInfo: {
    let customHeaders = [HAHeader(key: "key1", value: "value1"), HAHeader(key: "key2", value: "value2")]
    // Connection is required to be returned synchronously.
    // In a real implementation, handle both URL/connection info without crashing.
    try! .init(url: URL(string: "http://homeassistant.local:8123")!, customHeaders: customHeaders)
  },
  fetchAuthToken: { completion in
    // Access tokens are retrieved asynchronously, but be aware that Home Assistant
    // has a timeout of 10 seconds for sending your access token.
    completion(.success("API_Token_Here"))
  }
))
```

I added one check and all checks pass except one:

There was one test not working in "HAConnectionInfo.test.swift":

``` swift
func testInvalidURLComponentsURL() throws {
       // example of valid URL invalid URLComponents - https://stackoverflow.com/questions/55609012
       let url = try XCTUnwrap(URL(string: "a://@@/api/websocket"))
       let connectionInfo = try HAConnectionInfo(url: url)
       XCTAssertEqual(connectionInfo.url, url)
       XCTAssertEqual(connectionInfo.webSocket().request.url, url.appendingPathComponent("api/websocket"))
}
```

It basically checks if the url is valid. I commented it out because I was not sure how you wanna handle this. If you check the question on Stackoverflow, it seems to be resolved now. [https://stackoverflow.com/questions/55609012](url)