### PR TITLE
Use StarScream branch which prevents multiple URLSession creation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -12,11 +12,11 @@
       },
       {
         "package": "Starscream",
-        "repositoryURL": "https://github.com/daltoniam/Starscream",
+        "repositoryURL": "https://github.com/bgoncal/Starscream",
         "state": {
-          "branch": null,
-          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
-          "version": "4.0.4"
+          "branch": "ha-URLSession-fix",
+          "revision": "7e3d24425c20649105cb4bdd612b6bab66f73ade",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ public let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/daltoniam/Starscream",
-            from: "4.0.4"
+            url: "https://github.com/bgoncal/Starscream",
+            .branchItem("ha-URLSession-fix")
         ),
         .package(
             url: "https://github.com/mxcl/PromiseKit",

--- a/Source/Internal/HAConnectionImpl+Responses.swift
+++ b/Source/Internal/HAConnectionImpl+Responses.swift
@@ -1,7 +1,7 @@
 import Starscream
 
 extension HAConnectionImpl: Starscream.WebSocketDelegate {
-    func didReceive(event: Starscream.WebSocketEvent, client: Starscream.WebSocket) {
+    func didReceive(event: Starscream.WebSocketEvent, client: any Starscream.WebSocketClient) {
         responseController.didReceive(event: event)
     }
 }

--- a/Source/Internal/ResponseController/HAResponseController.swift
+++ b/Source/Internal/ResponseController/HAResponseController.swift
@@ -124,6 +124,8 @@ internal class HAResponseControllerImpl: HAResponseController {
         case let .error(error):
             HAGlobal.log(.error, "Error: \(String(describing: error))")
             phase = .disconnected(error: error, forReset: false)
+        case .peerClosed:
+            HAGlobal.log(.info, "Peer closed")
         }
     }
 

--- a/Source/Internal/ResponseController/HAResponseController.swift
+++ b/Source/Internal/ResponseController/HAResponseController.swift
@@ -126,6 +126,7 @@ internal class HAResponseControllerImpl: HAResponseController {
             phase = .disconnected(error: error, forReset: false)
         case .peerClosed:
             HAGlobal.log(.info, "Peer closed")
+            phase = .disconnected(error: nil, forReset: false)
         }
     }
 

--- a/Tests/HAResponseController.test.swift
+++ b/Tests/HAResponseController.test.swift
@@ -72,6 +72,14 @@ internal class HAResponseControllerTests: XCTestCase {
         }
     }
 
+    func testPeerClosedEvent() {
+        fireConnected()
+        controller.didReceive(event: .peerClosed)
+        waitForCallback()
+        XCTAssertEqual(delegate.lastPhase, .disconnected(error: nil, forReset: false))
+        XCTAssertNil(delegate.lastReceived)
+    }
+
     func testAuthFlow() throws {
         fireConnected()
         try fireText(


### PR DESCRIPTION
StarScream seems to be creating one URLSession per request, which is against Apple's recommendation of reusing existing URLSession.
Besides that apparently this also has a consequence of in a "retry loop" in Home Assistant App, user may never be able to reconnect due to error `POSIXErrorCode(rawValue: 28): No space left on device)` which comes from the limit of URLSession's allowed.

Related issue: https://github.com/home-assistant/iOS/issues/2638
My PR to StarScream: https://github.com/daltoniam/Starscream/pull/1011