### PR TITLE
Use starscream fork fix but pointing to version instead of branch

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,9 +14,9 @@
         "package": "Starscream",
         "repositoryURL": "https://github.com/bgoncal/Starscream",
         "state": {
-          "branch": "ha-URLSession-fix",
+          "branch": null,
           "revision": "7e3d24425c20649105cb4bdd612b6bab66f73ade",
-          "version": null
+          "version": "4.0.8"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ public let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/bgoncal/Starscream",
-            .branchItem("ha-URLSession-fix")
+            from: "4.0.8"
         ),
         .package(
             url: "https://github.com/mxcl/PromiseKit",


### PR DESCRIPTION
Tentative to avoid issue "Failed to resolve dependencies Dependencies could not be resolved because package 'hakit' is required using a stable-version but 'hakit' depends on an unstable-version package 'starscream' and root depends on 'hakit' 0.4.1." 