### PR TITLE
Allow passing data when subscribing for state updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2024-11-12
+- Changed: Allow passing data to entities state subcription, so you can filter what you want to receive
+
 ## [0.4.2] - 2024-04-22
 - Changed: Avoid JSON cache by JSONSerialization NSString
 

--- a/HAKit.podspec
+++ b/HAKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'HAKit'
-  s.version = '0.4.2'
+  s.version = '0.4.3'
   s.summary = 'Communicate with a Home Assistant instance.'
   s.author = 'Home Assistant'
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ To add it to an Xcode project, you can do this by adding the URL to File > Swift
 Add the following line to your Podfile:
 
 ```ruby
-pod "HAKit", "~> 0.4.2"
+pod "HAKit", "~> 0.4.3"
 # We are working from a fork of Starscream due to a necessary fix, please specify in your podfile
 pod 'Starscream', git: 'https://github.com/bgoncal/starscream', branch: 'ha-URLSession-fix'
 # pod "HAKit/PromiseKit" # optional, for PromiseKit support

--- a/Source/Caches/HACacheKeyStates.swift
+++ b/Source/Caches/HACacheKeyStates.swift
@@ -2,12 +2,12 @@ import Foundation
 
 /// Key for the cache
 internal struct HACacheKeyStates: HACacheKey {
-    static func create(connection: HAConnection) -> HACache<HACachedStates> {
+    static func create(connection: HAConnection, data: [String: Any]) -> HACache<HACachedStates> {
         .init(
             connection: connection,
             subscribe:
             .init(
-                subscription: .subscribeEntities(),
+                subscription: .subscribeEntities(data: data),
                 transform: { info in
                     .replace(processUpdates(
                         info: info,

--- a/Source/Caches/HACachedStates.swift
+++ b/Source/Caches/HACachedStates.swift
@@ -1,6 +1,10 @@
 public extension HACachesContainer {
     /// Cache of entity states, see `HACachedStates` for values.
-    var states: HACache<HACachedStates> { self[HACacheKeyStates.self] }
+    /// - Parameter data: The data passed to connection request
+    /// - Returns: The cache object with states
+    func states(_ data: [String: Any] = [:]) -> HACache<HACachedStates> {
+        self[HACacheKeyStates.self, data]
+    }
 }
 
 /// Cached version of all entity states

--- a/Source/Caches/HACachedUser.swift
+++ b/Source/Caches/HACachedUser.swift
@@ -5,7 +5,7 @@ public extension HACachesContainer {
 
 /// Key for the cache
 private struct HACacheKeyCurrentUser: HACacheKey {
-    static func create(connection: HAConnection) -> HACache<HAResponseCurrentUser> {
+    static func create(connection: HAConnection, data: [String: Any]) -> HACache<HAResponseCurrentUser> {
         .init(
             connection: connection,
             populate: .init(request: .currentUser(), transform: \.incoming),

--- a/Source/Caches/HACachesContainer.swift
+++ b/Source/Caches/HACachesContainer.swift
@@ -6,9 +6,14 @@ public protocol HACacheKey {
     ///
     /// This is called exactly once per connection per cache key.
     ///
-    /// - Parameter connection: The connection to create on
+    /// - Parameters:
+    ///   - connection: The connection to create on
+    ///   - data: The data passed to connection request
     /// - Returns: The cache you want to associate with the key
-    static func create(connection: HAConnection) -> HACache<Value>
+    static func create(
+        connection: HAConnection,
+        data: [String: Any]
+    ) -> HACache<Value>
 }
 
 /// Container for caches
@@ -56,7 +61,7 @@ public class HACachesContainer {
     /// - SeeAlso: `HACachesContainer` class description for how to use keys to retrieve caches.
     /// - Subscript: The key to look up
     /// - Returns: Either the existing cache for the key, or a new one created on-the-fly if none was available
-    public subscript<KeyType: HACacheKey>(_ key: KeyType.Type) -> HACache<KeyType.Value> {
+    public subscript<KeyType: HACacheKey>(_ key: KeyType.Type, data: [String: Any] = [:]) -> HACache<KeyType.Value> {
         // ObjectIdentifier is globally unique per class _or_ meta type, and we're using meta type here
         let key = ObjectIdentifier(KeyType.self)
 
@@ -64,7 +69,7 @@ public class HACachesContainer {
             return value
         }
 
-        let value = KeyType.create(connection: connection)
+        let value = KeyType.create(connection: connection, data: data)
         values[key] = value
         return value
     }

--- a/Source/Convenience/States.swift
+++ b/Source/Convenience/States.swift
@@ -11,9 +11,10 @@ public extension HATypedSubscription {
     }
 
     /// Listen for compressed state changes of all entities
+    /// - Parameter data: The data passed to connection request
     /// - Returns: A typed subscriptions that can be sent via `HAConnection`
-    static func subscribeEntities() -> HATypedSubscription<HACompressedStatesUpdates> {
-        .init(request: .init(type: .subscribeEntities, data: [:]))
+    static func subscribeEntities(data: [String: Any]) -> HATypedSubscription<HACompressedStatesUpdates> {
+        .init(request: .init(type: .subscribeEntities, data: data))
     }
 }
 

--- a/Tests/HACachedStates.test.swift
+++ b/Tests/HACachedStates.test.swift
@@ -19,7 +19,7 @@ internal class HACachedStatesTests: XCTestCase {
     }
 
     func testPopulateAndSubscribeInfo() throws {
-        let cache = container.states
+        let cache = container.states()
         XCTAssertNil(cache.populateInfo)
         XCTAssertNil(cache.subscribeInfo)
         let subscribeOnlyInfo = try XCTUnwrap(cache.subscribeOnlyInfo)

--- a/Tests/HACachesContainer.test.swift
+++ b/Tests/HACachesContainer.test.swift
@@ -41,7 +41,7 @@ internal class HACachesContainerTests: XCTestCase {
 }
 
 private struct Key1: HACacheKey {
-    static func create(connection: HAConnection) -> HACache<Value1> {
+    static func create(connection: HAConnection, data: [String: Any]) -> HACache<Value1> {
         .init(
             connection: connection,
             populate: HACachePopulateInfo<Value1>(
@@ -61,7 +61,7 @@ private struct Value1: HADataDecodable {
 }
 
 private struct Key2: HACacheKey {
-    static func create(connection: HAConnection) -> HACache<Value1> {
+    static func create(connection: HAConnection, data: [String: Any]) -> HACache<Value1> {
         .init(
             connection: connection,
             populate: HACachePopulateInfo<Value1>(

--- a/Tests/States.test.swift
+++ b/Tests/States.test.swift
@@ -141,7 +141,7 @@ internal class StatesTests: XCTestCase {
     }
 
     func testSubscribeEntitiesRequest() throws {
-        let request = HATypedSubscription<HACompressedStatesUpdates>.subscribeEntities()
+        let request = HATypedSubscription<HACompressedStatesUpdates>.subscribeEntities(data: [:])
         XCTAssertEqual(request.request.type, .subscribeEntities)
     }
 }


### PR DESCRIPTION
So we can subscribe only for the entities/domains that the app would actually use.
Related: 
- https://github.com/home-assistant/core/pull/124641
- https://github.com/home-assistant/iOS/pull/3154