### PR TITLE
Fix: Memory leaks

### DIFF
--- a/Source/Internal/HAConnectionImpl.swift
+++ b/Source/Internal/HAConnectionImpl.swift
@@ -98,7 +98,7 @@ internal class HAConnectionImpl: HAConnection {
                 to: .events(event),
                 allowConnecting: false,
                 initiated: nil,
-                handler: { [requestController] _, _ in requestController.retrySubscriptions() }
+                handler: { [weak requestController] _, _ in requestController?.retrySubscriptions() }
             )
         }
     }

--- a/Source/Internal/HAReconnectManager.swift
+++ b/Source/Internal/HAReconnectManager.swift
@@ -106,6 +106,12 @@ internal class HAReconnectManagerImpl: HAReconnectManager {
         #endif
     }
 
+    deinit {
+        #if canImport(Network)
+        pathMonitor.cancel()
+        #endif
+    }
+
     private func reset() {
         state.mutate { state in
             state.reset()


### PR DESCRIPTION
### Summary

This PR fixes two memory leak issues:

1. **NWPathMonitor** was not properly cancelled, causing retain cycles and memory leaks.
2. requestController retained cycles 

### Changes

- Add `monitor.cancel()` in appropriate deinit or shutdown logic.
- Fix retain cycle by using `[weak self]` in closures.
- Add relevant cleanup code to avoid strong references.

### Motivation

These issues caused retained cycles in production use, especially with reconnect behavior and long-running sessions.
