### PR TITLE
Pin SHA for all Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "06:00"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install Dependencies
         run: brew bundle      
       - name: "Run Linting"
@@ -24,7 +24,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Install Dependencies
         run: brew bundle
       - name: Run Tests
@@ -43,7 +43,7 @@ jobs:
             "${COV_BIN}" \
             -instr-profile=.build/debug/codecov/default.profdata \
             -ignore-filename-regex=".build|Tests"\ > info.lcov
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         name: Upload Code Coverage
         with:
           file: ./info.lcov

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install Jazzy
         run: gem install jazzy
       - name: Build Docs
         run: make docs
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs


### PR DESCRIPTION
Done by a tool: 
* https://github.com/Skipants/update-action-pins
* Added dependabot
* Pinning actions/checkout from master. 