### PR TITLE
Enable mTLS client identity on watchOS

### DIFF
--- a/Source/HAConnectionInfo.swift
+++ b/Source/HAConnectionInfo.swift
@@ -1,6 +1,16 @@
 import Foundation
 import Starscream
 
+#if os(watchOS)
+// CFNetwork's CFSocketStream.h — which declares these SSL stream property keys — is not part of the
+// watchOS SDK headers, even though the symbols are present in the CFNetwork binary. The keys are
+// public, documented CFStrings whose values are equal to their names, so we re-declare them by value
+// here to enable client-certificate (mTLS) configuration of the WebSocket stream on watchOS too.
+private let kCFStreamSSLCertificates = "kCFStreamSSLCertificates" as CFString
+private let kCFStreamSSLValidatesCertificateChain = "kCFStreamSSLValidatesCertificateChain" as CFString
+private let kCFStreamPropertySSLSettings = "kCFStreamPropertySSLSettings" as CFString
+#endif
+
 /// Information for connecting to the server
 public struct HAConnectionInfo: Equatable {
     /// Thrown if connection info was not able to be created
@@ -14,12 +24,9 @@ public struct HAConnectionInfo: Equatable {
     /// Certificate validation handler
     public typealias EvaluateCertificate = (SecTrust, (Result<Void, Error>) -> Void) -> Void
 
-    #if !os(watchOS)
     /// Client identity provider for mTLS
     public typealias ClientIdentityProvider = () -> SecIdentity?
-    #endif
 
-    #if !os(watchOS)
     /// Create a connection info
     public init(
         url: URL,
@@ -35,23 +42,7 @@ public struct HAConnectionInfo: Equatable {
             engine: nil
         )
     }
-    #else
-    /// Create a connection info
-    public init(
-        url: URL,
-        userAgent: String? = nil,
-        evaluateCertificate: EvaluateCertificate? = nil
-    ) throws {
-        try self.init(
-            url: url,
-            userAgent: userAgent,
-            evaluateCertificate: evaluateCertificate,
-            engine: nil
-        )
-    }
-    #endif
 
-    #if !os(watchOS)
     /// Internally create a connection info with engine
     internal init(
         url: URL,
@@ -74,28 +65,6 @@ public struct HAConnectionInfo: Equatable {
         self.evaluateCertificate = evaluateCertificate
         self.clientIdentity = clientIdentity
     }
-    #else
-    /// Internally create a connection info with engine
-    internal init(
-        url: URL,
-        userAgent: String?,
-        evaluateCertificate: EvaluateCertificate?,
-        engine: Engine?
-    ) throws {
-        guard let host = url.host, !host.isEmpty else {
-            throw CreationError.emptyHostname
-        }
-
-        guard (url.port ?? 80) <= UInt16.max else {
-            throw CreationError.invalidPort
-        }
-
-        self.url = Self.sanitize(url)
-        self.userAgent = userAgent
-        self.engine = engine
-        self.evaluateCertificate = evaluateCertificate
-    }
-    #endif
 
     /// The base URL for the WebSocket connection
     public var url: URL
@@ -113,10 +82,8 @@ public struct HAConnectionInfo: Equatable {
     /// Used to validate certificate, if provided
     internal var evaluateCertificate: EvaluateCertificate?
 
-    #if !os(watchOS)
     /// Used to provide client identity (SecIdentity) for mTLS
     internal var clientIdentity: ClientIdentityProvider?
-    #endif
 
     /// Should this connection info take over an existing connection?
     internal func shouldReplace(_ webSocket: WebSocket) -> Bool {
@@ -160,7 +127,6 @@ public struct HAConnectionInfo: Equatable {
         let request = self.request(url: webSocketURL)
         let webSocket: WebSocket
 
-        #if !os(watchOS)
         if let engine = engine {
             webSocket = WebSocket(request: request, engine: engine)
         } else if let clientIdentity = clientIdentity {
@@ -179,14 +145,6 @@ public struct HAConnectionInfo: Equatable {
             let pinning = evaluateCertificate.flatMap { HAStarscreamCertificatePinningImpl(evaluateCertificate: $0) }
             webSocket = WebSocket(request: request, certPinner: pinning, compressionHandler: WSCompression())
         }
-        #else
-        if let engine = engine {
-            webSocket = WebSocket(request: request, engine: engine)
-        } else {
-            let pinning = evaluateCertificate.flatMap { HAStarscreamCertificatePinningImpl(evaluateCertificate: $0) }
-            webSocket = WebSocket(request: request, certPinner: pinning, compressionHandler: WSCompression())
-        }
-        #endif
 
         return webSocket
     }
@@ -210,7 +168,6 @@ public struct HAConnectionInfo: Equatable {
         return components.url!
     }
 
-    #if !os(watchOS)
     /// Builds the SSL stream settings dictionary for client certificate configuration.
     /// - Parameters:
     ///   - certificateArray: Array of `SecIdentity`/`SecCertificate` for `kCFStreamSSLCertificates`, or nil
@@ -259,7 +216,6 @@ public struct HAConnectionInfo: Equatable {
             }
         }
     }
-    #endif
 
     public static func == (lhs: HAConnectionInfo, rhs: HAConnectionInfo) -> Bool {
         lhs.url == rhs.url

--- a/Source/HAConnectionInfo.swift
+++ b/Source/HAConnectionInfo.swift
@@ -8,9 +8,9 @@ import Starscream
 // here to enable client-certificate (mTLS) configuration of the WebSocket stream on watchOS too.
 // Kept `internal` (not `private`) so `@testable` watchOS test builds can reference them like the SDK
 // constants they stand in for.
-let kCFStreamSSLCertificates = "kCFStreamSSLCertificates" as CFString
-let kCFStreamSSLValidatesCertificateChain = "kCFStreamSSLValidatesCertificateChain" as CFString
-let kCFStreamPropertySSLSettings = "kCFStreamPropertySSLSettings" as CFString
+internal let kCFStreamSSLCertificates = "kCFStreamSSLCertificates" as CFString
+internal let kCFStreamSSLValidatesCertificateChain = "kCFStreamSSLValidatesCertificateChain" as CFString
+internal let kCFStreamPropertySSLSettings = "kCFStreamPropertySSLSettings" as CFString
 #endif
 
 /// Information for connecting to the server

--- a/Source/HAConnectionInfo.swift
+++ b/Source/HAConnectionInfo.swift
@@ -6,9 +6,11 @@ import Starscream
 // watchOS SDK headers, even though the symbols are present in the CFNetwork binary. The keys are
 // public, documented CFStrings whose values are equal to their names, so we re-declare them by value
 // here to enable client-certificate (mTLS) configuration of the WebSocket stream on watchOS too.
-private let kCFStreamSSLCertificates = "kCFStreamSSLCertificates" as CFString
-private let kCFStreamSSLValidatesCertificateChain = "kCFStreamSSLValidatesCertificateChain" as CFString
-private let kCFStreamPropertySSLSettings = "kCFStreamPropertySSLSettings" as CFString
+// Kept `internal` (not `private`) so `@testable` watchOS test builds can reference them like the SDK
+// constants they stand in for.
+let kCFStreamSSLCertificates = "kCFStreamSSLCertificates" as CFString
+let kCFStreamSSLValidatesCertificateChain = "kCFStreamSSLValidatesCertificateChain" as CFString
+let kCFStreamPropertySSLSettings = "kCFStreamPropertySSLSettings" as CFString
 #endif
 
 /// Information for connecting to the server

--- a/Tests/HAConnectionInfo.test.swift
+++ b/Tests/HAConnectionInfo.test.swift
@@ -242,7 +242,6 @@ internal class HAConnectionInfoTests: XCTestCase {
         }
     }
 
-    #if !os(watchOS)
     func testCreationWithClientIdentity() throws {
         let url = try XCTUnwrap(URL(string: "http://example.com/with_client_identity"))
 
@@ -359,5 +358,4 @@ internal class HAConnectionInfoTests: XCTestCase {
         webSocket.write(string: "test")
         XCTAssertTrue(engine.events.contains(.writeString("test")))
     }
-    #endif
 }


### PR DESCRIPTION
## Summary

Enables mutual TLS (client-certificate) authentication on **watchOS**. Previously the client-identity provider and the WebSocket stream-SSL configuration were gated behind `#if !os(watchOS)`, so a watchOS client could never present a client certificate during the TLS handshake — only iOS/macOS/tvOS could use mTLS.

## What changed

- **`HAConnectionInfo`** now exposes the `clientIdentity` provider on **all** platforms through a single unified initializer (the separate watchOS-only initializer is gone), and uses it via `FoundationTransport`'s stream configuration in `webSocket()`.
- The CFStream SSL setting keys — `kCFStreamSSLCertificates`, `kCFStreamSSLValidatesCertificateChain`, `kCFStreamPropertySSLSettings` — are **not declared in the watchOS SDK headers** even though the symbols exist in the CFNetwork binary. They're re-declared by their documented string values under `#if os(watchOS)` so the existing SSL-settings code compiles and links on watchOS. (Their CFString values equal their names; verified against macOS where the headers are present.)
- The mTLS-related tests in `HAConnectionInfo.test.swift` are no longer gated to non-watchOS.

The net diff is mostly removal of the duplicated, platform-guarded code paths.

## Why

The Home Assistant companion app is adding mTLS support to its Apple Watch app. The watch connects directly to Home Assistant (WebSocket + REST) when the paired iPhone isn't reachable, so it must present the client certificate itself — impossible while HAKit compiles out `clientIdentity` on watchOS.

## Notes for reviewers

- No API change for existing platforms: the unified `init` keeps the same `clientIdentity:` parameter (default `nil`) that iOS/macOS/tvOS already used.
- The string-value re-declaration of the CFStream keys is the load-bearing part — it's the only way to set client certificates on a `FoundationTransport` stream on watchOS, since Apple ships the symbols but not the headers there.

## Testing

- Builds for watchOS and the existing platforms.
- Verified at runtime on watchOS: the WebSocket mTLS handshake completes and the server (nginx with `ssl_verify_client`) accepts the presented client certificate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
