### PR TITLE
Bump 0.4.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.15] - 2026-06-16
+- Added: mTLS client certificate support on watchOS (`HAConnectionInfo` now accepts a `clientIdentity` provider on all platforms).
+
 ## [0.4.14] - 2026-04-15
 - Fixed: Skip invalid `HAEntity` items when decoding arrays so valid entities can still be returned.
 

--- a/HAKit.podspec
+++ b/HAKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'HAKit'
-  s.version = '0.4.14'
+  s.version = '0.4.15'
   s.summary = 'Communicate with a Home Assistant instance.'
   s.author = 'Home Assistant'
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ To add it to an Xcode project, you can do this by adding the URL to File > Swift
 Add the following line to your Podfile:
 
 ```ruby
-pod "HAKit", "~> 0.4.14"
+pod "HAKit", "~> 0.4.15"
 # We are working from a fork of Starscream due to a necessary fix, please specify in your podfile
 pod 'Starscream', git: 'https://github.com/bgoncal/starscream', branch: 'ha-URLSession-fix'
 # pod "HAKit/PromiseKit" # optional, for PromiseKit support


### PR DESCRIPTION
## Summary

Placeholder release bump to **0.4.15** for the watchOS mTLS client-certificate support added in #108.

Kept as a **draft** — merge this only after #108 lands, then tag `0.4.15` so the Home Assistant companion app can pin the released version (instead of the local `:path` it's using during development).

## Changes
- `HAKit.podspec`: `0.4.14` → `0.4.15`
- `README.md`: CocoaPods install snippet → `~> 0.4.15`
- `CHANGELOG.md`: new `## [0.4.15]` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
