### PR TITLE
Bump 0.4.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.17] - 2026-06-30
+- Added: `HAKit+PromiseKit` and `HAKit+Mocks` are now exposed as Swift Package Manager library products, so SPM consumers can depend on them directly (previously only reachable through the CocoaPods subspecs).
+
 ## [0.4.16] - 2026-06-17
 - Fixed: WebSocket compression (permessage-deflate) frames failing to decode on watchOS — the watch now connects without compression, fixing dropped connections to servers that negotiate it.
 

--- a/HAKit.podspec
+++ b/HAKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'HAKit'
-  s.version = '0.4.16'
+  s.version = '0.4.17'
   s.summary = 'Communicate with a Home Assistant instance.'
   s.author = 'Home Assistant'
 

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ To add it to an Xcode project, you can do this by adding the URL to File > Swift
 Add the following line to your Podfile:
 
 ```ruby
-pod "HAKit", "~> 0.4.16"
+pod "HAKit", "~> 0.4.17"
 # We are working from a fork of Starscream due to a necessary fix, please specify in your podfile
 pod 'Starscream', git: 'https://github.com/bgoncal/starscream', branch: 'ha-URLSession-fix'
 # pod "HAKit/PromiseKit" # optional, for PromiseKit support


### PR DESCRIPTION
Release the SPM products exposed in #113.

## Changes
- `HAKit.podspec`: `0.4.16` → `0.4.17`
- `CHANGELOG.md`: new `0.4.17` entry
- `README.md`: Podfile example bumped to `~> 0.4.17`

## Changelog entry
- Added: `HAKit+PromiseKit` and `HAKit+Mocks` are now exposed as Swift Package Manager library products, so SPM consumers can depend on them directly (previously only reachable through the CocoaPods subspecs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)